### PR TITLE
Setting for microhard channel/frequency

### DIFF
--- a/src/Microhard/MicrohardManager.h
+++ b/src/Microhard/MicrohardManager.h
@@ -20,6 +20,8 @@
 class AppSettings;
 class QGCApplication;
 
+#define DEFAULT_PAIRING_CHANNEL 78
+
 //-----------------------------------------------------------------------------
 class MicrohardManager : public QGCTool
 {
@@ -30,14 +32,16 @@ public:
     Q_PROPERTY(int          linkConnected       READ linkConnected                              NOTIFY linkConnectedChanged)
     Q_PROPERTY(int          uplinkRSSI          READ uplinkRSSI                                 NOTIFY linkChanged)
     Q_PROPERTY(int          downlinkRSSI        READ downlinkRSSI                               NOTIFY linkChanged)
-    Q_PROPERTY(QString      localIPAddr         READ localIPAddr      WRITE setLocalIPAddr      NOTIFY localIPAddrChanged)
-    Q_PROPERTY(QString      remoteIPAddr        READ remoteIPAddr     WRITE setRemoteIPAddr     NOTIFY remoteIPAddrChanged)
+    Q_PROPERTY(QString      localIPAddr         READ localIPAddr         WRITE setLocalIPAddr   NOTIFY localIPAddrChanged)
+    Q_PROPERTY(QString      remoteIPAddr        READ remoteIPAddr        WRITE setRemoteIPAddr  NOTIFY remoteIPAddrChanged)
     Q_PROPERTY(QString      netMask             READ netMask                                    NOTIFY netMaskChanged)
     Q_PROPERTY(QString      configUserName      READ configUserName                             NOTIFY configUserNameChanged)
     Q_PROPERTY(QString      configPassword      READ configPassword                             NOTIFY configPasswordChanged)
     Q_PROPERTY(QString      encryptionKey       READ encryptionKey                              NOTIFY encryptionKeyChanged)
+    Q_PROPERTY(int          connectingChannel   READ connectingChannel                          NOTIFY connectingChannelChanged)
+    Q_PROPERTY(QStringList  channelLabels       READ channelLabels                              NOTIFY channelLabelsChanged)
 
-    Q_INVOKABLE bool setIPSettings              (QString localIP, QString remoteIP, QString netMask, QString cfgUserName, QString cfgPassword, QString encyrptionKey);
+    Q_INVOKABLE bool setIPSettings              (QString localIP, QString remoteIP, QString netMask, QString cfgUserName, QString cfgPassword, QString encyrptionKey, int channel);
 
     explicit MicrohardManager                   (QGCApplication* app, QGCToolbox* toolbox);
     ~MicrohardManager                           () override;
@@ -54,14 +58,15 @@ public:
     QString     configUserName                  () { return _configUserName; }
     QString     configPassword                  () { return _configPassword; }
     QString     encryptionKey                   () { return _encryptionKey; }
+    int         connectingChannel               () { return _connectingChannel; }
+    QStringList channelLabels                   () { return _channelLabels; }
 
     void        setLocalIPAddr                  (QString val) { _localIPAddr = val; emit localIPAddrChanged(); }
     void        setRemoteIPAddr                 (QString val) { _remoteIPAddr = val; emit remoteIPAddrChanged(); }
     void        setConfigUserName               (QString val) { _configUserName = val; emit configUserNameChanged(); }
     void        setConfigPassword               (QString val) { _configPassword = val; emit configPasswordChanged(); }
-    void        setEncryptionKey                (QString val) { _encryptionKey = val; emit encryptionKeyChanged(); }
     void        updateSettings                  ();
-    void        setEncryptionKey                ();
+    void        configure                       ();
     void        switchToPairingEncryptionKey    ();
     void        switchToConnectionEncryptionKey (QString encryptionKey);
 
@@ -75,6 +80,8 @@ signals:
     void    configUserNameChanged           ();
     void    configPasswordChanged           ();
     void    encryptionKeyChanged            ();
+    void    connectingChannelChanged        ();
+    void    channelLabelsChanged            ();
 
 private slots:
     void    _connectedLoc                   (int status);
@@ -109,7 +116,12 @@ private:
     QString            _configUserName;
     QString            _configPassword;
     QString            _encryptionKey;
-    bool               _useCommunicationEncryptionKey = false;
     QString            _communicationEncryptionKey;
+    bool               _usePairingSettings = true;
+    QString            _pairingPower = "7";
+    QString            _connectingPower = "30";
+    int                _pairingChannel = DEFAULT_PAIRING_CHANNEL;
+    int                _connectingChannel = DEFAULT_PAIRING_CHANNEL;
+    QStringList        _channelLabels;
     QTime              _timeoutTimer;
 };

--- a/src/Microhard/MicrohardSettings.h
+++ b/src/Microhard/MicrohardSettings.h
@@ -15,10 +15,10 @@ class MicrohardSettings : public MicrohardHandler
 {
     Q_OBJECT
 public:
-    explicit MicrohardSettings          (QString address, QObject* parent = nullptr, bool setEncryptionKey = false);
+    explicit MicrohardSettings          (QString address, QObject* parent = nullptr, bool configure = false);
     bool    start                       () override;
     void    getStatus                   ();
-    void    setEncryptionKey            (QString key);
+    void    configure                   (QString key, QString power, int channel);
     bool    loggedIn                    () { return _loggedIn; }
 
 protected slots:
@@ -31,5 +31,6 @@ private:
     bool    _loggedIn;
     int     _rssiVal;
     QString _address;
-    bool    _setEncryptionKey;
+    bool    _configure;
+    bool    _configureAfterConnect{false};
 };

--- a/src/Microhard/MicrohardSettings.qml
+++ b/src/Microhard/MicrohardSettings.qml
@@ -254,6 +254,15 @@ Rectangle {
                                 echoMode:       TextInput.Password
                                 Layout.minimumWidth: _valueWidth
                             }
+                            QGCLabel {
+                                text:           qsTr("Channel:")
+                            }
+                            QGCComboBox {
+                                id:             connectingChannel
+                                model:          QGroundControl.microhardManager.channelLabels
+                                currentIndex:   QGroundControl.microhardManager.connectingChannel - 1
+                                Layout.minimumWidth: _valueWidth
+                            }
                         }
                         Item {
                             width:  1
@@ -266,12 +275,13 @@ Rectangle {
                                 return false
                             }
                             function testEnabled() {
-                                if(localIP.text          === QGroundControl.microhardManager.localIPAddr &&
-                                    remoteIP.text        === QGroundControl.microhardManager.remoteIPAddr &&
-                                    netMask.text         === QGroundControl.microhardManager.netMask &&
-                                    configUserName.text  === QGroundControl.microhardManager.configUserName &&
-                                    configPassword.text  === QGroundControl.microhardManager.configPassword &&
-                                    encryptionKey.text   === QGroundControl.microhardManager.encryptionKey)
+                                if(localIP.text            === QGroundControl.microhardManager.localIPAddr &&
+                                    remoteIP.text          === QGroundControl.microhardManager.remoteIPAddr &&
+                                    netMask.text           === QGroundControl.microhardManager.netMask &&
+                                    configUserName.text    === QGroundControl.microhardManager.configUserName &&
+                                    configPassword.text    === QGroundControl.microhardManager.configPassword &&
+                                    encryptionKey.text     === QGroundControl.microhardManager.encryptionKey &&
+                                    connectingChannel.text === QGroundControl.microhardManager.connectingChannel)
                                     return false
                                 if(!validateIPaddress(localIP.text))  return false
                                 if(!validateIPaddress(remoteIP.text)) return false
@@ -282,7 +292,13 @@ Rectangle {
                             text:               qsTr("Apply")
                             anchors.horizontalCenter:   parent.horizontalCenter
                             onClicked: {
-                                QGroundControl.microhardManager.setIPSettings(localIP.text, remoteIP.text, netMask.text, configUserName.text, configPassword.text, encryptionKey.text)
+                                QGroundControl.microhardManager.setIPSettings(localIP.text,
+                                                                              remoteIP.text,
+                                                                              netMask.text,
+                                                                              configUserName.text,
+                                                                              configPassword.text,
+                                                                              encryptionKey.text,
+                                                                              connectingChannel.currentIndex + 1)
                             }
 
                         }

--- a/src/PairingManager/PairingManager.cc
+++ b/src/PairingManager/PairingManager.cc
@@ -679,6 +679,7 @@ PairingManager::_createMicrohardPairingJson()
     jsonObj.insert("IP", localIP);
     jsonObj.insert("EK", _encryptionKey);
     jsonObj.insert("PublicKey", _publicKey);
+    jsonObj.insert("CC", _toolbox->microhardManager()->connectingChannel());
     return QJsonDocument(jsonObj);
 }
 


### PR DESCRIPTION
Add a setting in Microhard settings for the channel used during communication.
During pairing phase a different pairing channel is used which is by default set to 78. The channel that is set in Microhard settings panel is then transfered to pairing-manager on companion computer side and in order to establish a connection both sides have to switch to this user selected channel.
![MicrohardChannel](https://user-images.githubusercontent.com/7646986/65506832-d0d7a980-decc-11e9-8a8d-bfe5397b590b.png)
