### PR TITLE
Set channel select labels based on modem product name

### DIFF
--- a/src/Microhard/MicrohardManager.h
+++ b/src/Microhard/MicrohardManager.h
@@ -40,6 +40,8 @@ public:
     Q_PROPERTY(QString      encryptionKey       READ encryptionKey                              NOTIFY encryptionKeyChanged)
     Q_PROPERTY(int          connectingChannel   READ connectingChannel                          NOTIFY connectingChannelChanged)
     Q_PROPERTY(QStringList  channelLabels       READ channelLabels                              NOTIFY channelLabelsChanged)
+    Q_PROPERTY(int          channelMin          READ channelMin                                 NOTIFY channelMinChanged)
+    Q_PROPERTY(int          channelMax          READ channelMax                                 NOTIFY channelMaxChanged)
 
     Q_INVOKABLE bool setIPSettings              (QString localIP, QString remoteIP, QString netMask, QString cfgUserName, QString cfgPassword, QString encyrptionKey, int channel);
 
@@ -60,6 +62,8 @@ public:
     QString     encryptionKey                   () { return _encryptionKey; }
     int         connectingChannel               () { return _connectingChannel; }
     QStringList channelLabels                   () { return _channelLabels; }
+    int         channelMin                      () { return _channelMin; }
+    int         channelMax                      () { return _channelMax; }
 
     void        setLocalIPAddr                  (QString val) { _localIPAddr = val; emit localIPAddrChanged(); }
     void        setRemoteIPAddr                 (QString val) { _remoteIPAddr = val; emit remoteIPAddrChanged(); }
@@ -83,6 +87,8 @@ signals:
     void    encryptionKeyChanged            ();
     void    connectingChannelChanged        ();
     void    channelLabelsChanged            ();
+    void    channelMinChanged               ();
+    void    channelMaxChanged               ();
 
 private slots:
     void    _connectedLoc                   (int status);
@@ -127,5 +133,4 @@ private:
     QTime              _timeoutTimer;
     int                _channelMin = 1;
     int                _channelMax = 81;
-
 };

--- a/src/Microhard/MicrohardManager.h
+++ b/src/Microhard/MicrohardManager.h
@@ -69,6 +69,7 @@ public:
     void        configure                       ();
     void        switchToPairingEncryptionKey    ();
     void        switchToConnectionEncryptionKey (QString encryptionKey);
+    void        setProductName                  (QString product);
 
 signals:
     void    linkChanged                     ();
@@ -124,4 +125,7 @@ private:
     int                _connectingChannel = DEFAULT_PAIRING_CHANNEL;
     QStringList        _channelLabels;
     QTime              _timeoutTimer;
+    int                _channelMin = 1;
+    int                _channelMax = 81;
+
 };

--- a/src/Microhard/MicrohardSettings.cc
+++ b/src/Microhard/MicrohardSettings.cc
@@ -65,6 +65,7 @@ MicrohardSettings::_readBytes()
     if (!_tcpSocket) {
         return;
     }
+    int j;
     QByteArray bytesIn = _tcpSocket->read(_tcpSocket->bytesAvailable());
 
     //qCDebug(MicrohardLog) << "Read bytes: " << bytesIn;
@@ -91,6 +92,18 @@ MicrohardSettings::_readBytes()
     } else if (bytesIn.contains("Login incorrect")) {
         emit connected(-1);
     } else if (bytesIn.contains("Entering")) {
+        if (!_configure) {
+            _loggedIn = true;
+            emit connected(1);
+        } else {
+            _tcpSocket->write("at+mssysi\n");
+        }
+    } else if ((j = bytesIn.indexOf("Product")) > 0) {
+        int i = bytesIn.indexOf(": ", j);
+        if (i > 0) {
+            QString product = bytesIn.mid(i + 2, bytesIn.indexOf("\r", i + 3) - (i + 2));
+            qgcApp()->toolbox()->microhardManager()->setProductName(product);
+        }
         if (!loggedIn() && (_configure || _configureAfterConnect)) {
             _configureAfterConnect = false;
             qgcApp()->toolbox()->microhardManager()->configure();

--- a/src/Microhard/MicrohardSettings.qml
+++ b/src/Microhard/MicrohardSettings.qml
@@ -260,7 +260,7 @@ Rectangle {
                             QGCComboBox {
                                 id:             connectingChannel
                                 model:          QGroundControl.microhardManager.channelLabels
-                                currentIndex:   QGroundControl.microhardManager.connectingChannel - 1
+                                currentIndex:   QGroundControl.microhardManager.connectingChannel - QGroundControl.microhardManager.channelMin
                                 Layout.minimumWidth: _valueWidth
                             }
                         }
@@ -298,7 +298,7 @@ Rectangle {
                                                                               configUserName.text,
                                                                               configPassword.text,
                                                                               encryptionKey.text,
-                                                                              connectingChannel.currentIndex + 1)
+                                                                              connectingChannel.currentIndex + QGroundControl.microhardManager.channelMin)
                             }
 
                         }


### PR DESCRIPTION
Microhard modems have different frequencies and channel range.
Create channel select labels based on MH modem product name.