### PR TITLE
Fix unitialized variable that might cause an undefined behaviour

### DIFF
--- a/src/QGCMapPalette.h
+++ b/src/QGCMapPalette.h
@@ -64,7 +64,7 @@ signals:
     void lightColorsChanged(bool lightColors);
     
 private:
-    bool _lightColors;
+    bool _lightColors = false;
 
     static const int _cColorGroups = 2;
 


### PR DESCRIPTION
CentOS startup stack dump:
```
#0  __base_ctor (this=<optimized out>, acolor=...) at /home/user/Qt/5.12.4/gcc_64/include/QtGui/qcolor.h:302
#1  thumbJoystick (this=<optimized out>) at moc/../../qgroundcontrol/src/QGCMapPalette.h:57
#2  QGCMapPalette::qt_static_metacall (_o=<optimized out>, _c=<optimized out>, _id=<optimized out>, _a=<optimized out>, _a=<optimized out>, _id=<optimized out>, _c=<optimized out>, _o=<optimized out>) at moc/moc_QGCMapPalette.cpp:122
#3  0x000000000044df3b in QGCMapPalette::qt_metacall (this=0x35dd8a0, _c=QMetaObject::ReadProperty, _id=1, _a=0x7fffbeff2650) at moc/moc_QGCMapPalette.cpp:178
```