### PR TITLE
Use Intel vaapi video hw acceleration

### DIFF
--- a/src/VideoStreaming/VideoReceiver.cc
+++ b/src/VideoStreaming/VideoReceiver.cc
@@ -625,6 +625,8 @@ VideoReceiver::setVideoDecoder(VideoEncoding encoding)
         _parserName = "h265parse";
 #if defined(__android__)
         _hwDecoderName = "amcviddec-omxgooglehevcdecoder";
+#else
+        _hwDecoderName = "vaapih265dec";
 #endif
         _swDecoderName = "avdec_h265";
     } else {
@@ -632,6 +634,8 @@ VideoReceiver::setVideoDecoder(VideoEncoding encoding)
         _parserName = "h264parse";
 #if defined(__android__)
         _hwDecoderName = "amcviddec-omxgoogleh264decoder";
+#else
+        _hwDecoderName = "vaapih264dec";
 #endif
         _swDecoderName = "avdec_h264";
     }


### PR DESCRIPTION
On Linux we should try to use VAAPI HW video decoding by default and if it doesn't work we fall back to software video decoding.