### PR TITLE
Fix popup hang on CentOS touch devices

### DIFF
--- a/src/ui/MainRootWindow.qml
+++ b/src/ui/MainRootWindow.qml
@@ -590,6 +590,29 @@ ApplicationWindow {
             height: loader.height
             color:  Qt.rgba(0,0,0,0)
         }
+        //-- Dismiss popup. Workaround for the can't get out of popup issue on CentOS touch devices after plugging out keyboard
+        QGCColoredImage {
+            property real _margins: ScreenTools.defaultFontPixelHeight * 0.5
+            x:                  visible ? loader.item.x + loader.item.width - _margins - width : 0
+            y:                  visible ? loader.item.y + _margins : 0
+            z:                  visible ? loader.item.z + 1 : 0
+            visible:            loader.item !== null
+            width:              ScreenTools.isMobile ? ScreenTools.defaultFontPixelHeight * 1.5 : ScreenTools.defaultFontPixelHeight
+            height:             width
+            sourceSize.height:  width
+            source:             "/res/XDelete.svg"
+            fillMode:           Image.PreserveAspectFit
+            mipmap:             true
+            smooth:             true
+            color:              qgcPal.text
+            MouseArea {
+                anchors.fill:       parent
+                anchors.margins:    ScreenTools.isMobile ? -ScreenTools.defaultFontPixelHeight : 0
+                onClicked: {
+                    indicatorDropdown.close()
+                }
+            }
+        }
         Loader {
             id:             loader
             onLoaded: {


### PR DESCRIPTION
Workaround for popup freeze on Panasonic Toughpad linux device. If the keyboard is plugged in or out while QGC is running, clicking outside the popup's content won't work until the application is restarted.
This patch addresses this by providing a close element on the top/right side of the popup's content.

![popup_close](https://user-images.githubusercontent.com/47554641/65985271-c182ce00-e481-11e9-9968-483d307d3578.png)
![popup_close_rssi](https://user-images.githubusercontent.com/47554641/65985273-c182ce00-e481-11e9-9351-25721998ab45.png)
