### PR TITLE
Disable custom build by default and add env var to enable it

### DIFF
--- a/qgroundcontrol.pro
+++ b/qgroundcontrol.pro
@@ -88,17 +88,31 @@ exists(user_config.pri):infile(user_config.pri, CONFIG) {
 # is present. It's useful to run "regular" builds to make sure you didn't
 # break anything.
 
+# Default build is disabled because of the constant presence of the custom build
+
+# QGC_CUSTOM_BUILD_FOLDER can be defined in dev environment to change the custom folder
+# this will also trigger enabling of custom build
+QGC_CUSTOM_BUILD_FOLDER=$$(QGC_CUSTOM_BUILD_FOLDER)
+isEmpty(QGC_CUSTOM_BUILD_FOLDER) {
+    # Use the default name for the custom folder: custom
+    QGC_CUSTOM_BUILD_FOLDER=$$PWD/$$QGC_CUSTOM_BUILD_FOLDER/custom.pri
+    # Default build is disabled because of the constant presence of the custom build
+    CONFIG += QGC_DISABLE_CUSTOM_BUILD
+} else {
+    message("Externally triggered custom build override")
+}
+
 contains (CONFIG, QGC_DISABLE_CUSTOM_BUILD) {
     message("Disable custom build override")
 } else {
-    exists($$PWD/custom/custom.pri) {
+    exists($${QGC_CUSTOM_BUILD_FOLDER}) {
         message("Found custom build")
         CONFIG  += CustomBuild
         DEFINES += QGC_CUSTOM_BUILD
         # custom.pri must define:
         # CUSTOMCLASS  = YourIQGCCorePluginDerivation
         # CUSTOMHEADER = \"\\\"YourIQGCCorePluginDerivation.h\\\"\"
-        include($$PWD/custom/custom.pri)
+        include($$PWD/$$QGC_CUSTOM_BUILD_FOLDER/custom.pri)
     }
 }
 
@@ -340,21 +354,21 @@ include(QGCExternalLibs.pri)
 #
 
 CustomBuild {
-    exists($$PWD/custom/qgroundcontrol.qrc) {
+    exists($$PWD/$$QGC_CUSTOM_BUILD_FOLDER/qgroundcontrol.qrc) {
         message("Using custom qgroundcontrol.qrc")
-        RESOURCES += $$PWD/custom/qgroundcontrol.qrc
+        RESOURCES += $$PWD/$$QGC_CUSTOM_BUILD_FOLDER/qgroundcontrol.qrc
     } else {
         RESOURCES += $$PWD/qgroundcontrol.qrc
     }
-    exists($$PWD/custom/qgcresources.qrc) {
+    exists($$PWD/$$QGC_CUSTOM_BUILD_FOLDER/qgcresources.qrc) {
         message("Using custom qgcresources.qrc")
-        RESOURCES += $$PWD/custom/qgcresources.qrc
+        RESOURCES += $$PWD/$$QGC_CUSTOM_BUILD_FOLDER/qgcresources.qrc
     } else {
         RESOURCES += $$PWD/qgcresources.qrc
     }
-    exists($$PWD/custom/qgcimages.qrc) {
+    exists($$PWD/$$QGC_CUSTOM_BUILD_FOLDER/qgcimages.qrc) {
         message("Using custom qgcimages.qrc")
-        RESOURCES += $$PWD/custom/qgcimages.qrc
+        RESOURCES += $$PWD/$$QGC_CUSTOM_BUILD_FOLDER/qgcimages.qrc
     } else {
         RESOURCES += $$PWD/qgcimages.qrc
     }


### PR DESCRIPTION
Disable custom by default. From now on the custom folder will be preset.
Add flag to change the custom folder which will also trigger enabling of custom build
Enable custom folder: `export QGC_CUSTOM_BUILD_FOLDER=custom`
Or add the variable in QT creator build environment:
![Screenshot from 2019-10-03 11-18-18](https://user-images.githubusercontent.com/47554641/66114709-b5a52200-e5cf-11e9-9b43-ba5b7d000cf7.png)
