### PR TITLE
Fix video issue when pairing is not enabled

### DIFF
--- a/src/PairingManager/PairingManager.cc
+++ b/src/PairingManager/PairingManager.cc
@@ -60,6 +60,15 @@ PairingManager::setToolbox(QGCToolbox *toolbox)
 }
 
 //-----------------------------------------------------------------------------
+bool
+PairingManager::videoCanRestart()
+{
+    return
+        !_toolbox->settingsManager()->appSettings()->usePairing()->rawValue().toBool() ||
+        !_connectedDevices.empty();
+}
+
+//-----------------------------------------------------------------------------
 void
 PairingManager::_pairingCompleted(const QString& name, const QString& devicePublicKey)
 {

--- a/src/PairingManager/PairingManager.h
+++ b/src/PairingManager/PairingManager.h
@@ -71,7 +71,7 @@ public:
     int             nfcIndex                    () { return _nfcIndex; }
     int             microhardIndex              () { return _microhardIndex; }
     bool            firstBoot                   () { return _firstBoot; }
-    bool            videoCanRestart             () { return !_connectedDevices.empty(); }
+    bool            videoCanRestart             ();
     bool            errorState                  () { return _status == PairingRejected || _status == PairingConnectionRejected || _status == PairingError; }
     void            setStatusMessage            (PairingStatus status, const QString& statusStr) { emit setPairingStatus(status, statusStr); }
     void            jsonReceived                (const QString& json) { emit parsePairingJson(json); }


### PR DESCRIPTION
Video was not started when pairing was disabled.
Changed condition for restarting video to include pairing enable/disable status.