### PR TITLE
Pr photo gallery wip todo

### DIFF
--- a/qgcimages.qrc
+++ b/qgcimages.qrc
@@ -122,6 +122,7 @@
         <file alias="no-logging.svg">src/AutoPilotPlugins/PX4/Images/no-logging.svg</file>
         <file alias="ObjectAvoidance.svg">src/AutoPilotPlugins/PX4/Images/ObjectAvoidance.svg</file>
         <file alias="PaperPlane.svg">src/ui/toolbar/Images/PaperPlane.svg</file>
+        <file alias="PhotoGallery.svg">src/ui/toolbar/Images/PhotoGallery.svg</file>
         <file alias="PiP.svg">src/FlightMap/Images/PiP.svg</file>
         <file alias="pipHide.svg">src/FlightMap/Images/pipHide.svg</file>
         <file alias="pipResize.svg">src/FlightMap/Images/pipResize.svg</file>

--- a/qgroundcontrol.pro
+++ b/qgroundcontrol.pro
@@ -418,6 +418,7 @@ INCLUDEPATH += \
     src/FlightMap/Widgets \
     src/FollowMe \
     src/GPS \
+    src/ImageGallery \
     src/Joystick \
     src/PlanView \
     src/MissionManager \
@@ -1372,6 +1373,11 @@ contains (CONFIG, DISABLE_VIDEOSTREAMING) {
 } else {
     include(src/VideoStreaming/VideoStreaming.pri)
 }
+
+#-------------------------------------------------------------------------------------
+# Video Streaming
+
+include(src/PhotoGallery/photogallery.pri)
 
 #-------------------------------------------------------------------------------------
 # Android

--- a/qgroundcontrol.qrc
+++ b/qgroundcontrol.qrc
@@ -37,6 +37,7 @@
         <file alias="GeoTagPage.qml">src/AnalyzeView/GeoTagPage.qml</file>
         <file alias="HealthPageWidget.qml">src/FlightMap/Widgets/HealthPageWidget.qml</file>
         <file alias="HelpSettings.qml">src/ui/preferences/HelpSettings.qml</file>
+        <file alias="PhotoGalleryView.qml">src/PhotoGallery/PhotoGalleryView.qml</file>
         <file alias="JoystickConfig.qml">src/VehicleSetup/JoystickConfig.qml</file>
         <file alias="JoystickConfigButtons.qml">src/VehicleSetup/JoystickConfigButtons.qml</file>
         <file alias="JoystickConfigAdvanced.qml">src/VehicleSetup/JoystickConfigAdvanced.qml</file>

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -126,6 +126,7 @@ add_subdirectory(FlightDisplay)
 add_subdirectory(FlightMap)
 add_subdirectory(FollowMe)
 add_subdirectory(GPS)
+add_subdirectory(PhotoGallery)
 add_subdirectory(Joystick)
 add_subdirectory(MissionManager)
 add_subdirectory(PlanView)
@@ -161,6 +162,7 @@ target_link_libraries(qgc
 		FlightMap
 		FollowMe
 		gps
+		PhotoGallery
 		Joystick
 		MissionManager
 		PositionManager

--- a/src/Camera/QGCCameraManager.cc
+++ b/src/Camera/QGCCameraManager.cc
@@ -97,6 +97,9 @@ QGCCameraManager::_mavlinkMessageReceived(const mavlink_message_t& message)
             case MAVLINK_MSG_ID_VIDEO_STREAM_STATUS:
                 _handleVideoStreamStatus(message);
                 break;
+            case MAVLINK_MSG_ID_CAMERA_IMAGE_CAPTURED:
+                _handleImageCapture(message);
+                break;
         }
     }
 }
@@ -355,6 +358,19 @@ QGCCameraManager::_handleVideoStreamStatus(const mavlink_message_t& message)
         mavlink_video_stream_status_t streamStatus;
         mavlink_msg_video_stream_status_decode(&message, &streamStatus);
         pCamera->handleVideoStatus(&streamStatus);
+    }
+}
+
+//-----------------------------------------------------------------------------
+void
+QGCCameraManager::_handleImageCapture(const mavlink_message_t& message)
+{
+    mavlink_camera_image_captured_t captureStatus;
+    mavlink_msg_camera_image_captured_decode(&message, &captureStatus);
+    if (captureStatus.capture_result == 1) {
+        emit imageCaptured(captureStatus.file_url);
+    } else {
+        emit imageCaptureFailure();
     }
 }
 

--- a/src/Camera/QGCCameraManager.h
+++ b/src/Camera/QGCCameraManager.h
@@ -51,6 +51,8 @@ signals:
     void    cameraLabelsChanged     ();
     void    currentCameraChanged    ();
     void    streamChanged           ();
+    void imageCaptured (const QString & uri);
+    void imageCaptureFailure();
 
 protected slots:
     virtual void    _vehicleReady           (bool ready);
@@ -83,6 +85,7 @@ protected:
     virtual void    _handleCaptureStatus    (const mavlink_message_t& message);
     virtual void    _handleVideoStreamInfo  (const mavlink_message_t& message);
     virtual void    _handleVideoStreamStatus(const mavlink_message_t& message);
+    virtual void    _handleImageCapture     (const mavlink_message_t& message);
 
 protected:
 

--- a/src/PhotoGallery/AbstractPhotoTrigger.cc
+++ b/src/PhotoGallery/AbstractPhotoTrigger.cc
@@ -1,0 +1,37 @@
+/****************************************************************************
+ *
+ *   (c) 2019 QGROUNDCONTROL PROJECT <http://www.qgroundcontrol.org>
+ *
+ * QGroundControl is licensed according to the terms in the file
+ * COPYING.md in the root of the source code directory.
+ *
+ ****************************************************************************/
+
+#include "AbstractPhotoTrigger.h"
+
+#include <QtQml>
+
+AbstractPhotoTriggerOperation::~AbstractPhotoTriggerOperation()
+{
+}
+
+AbstractPhotoTrigger::~AbstractPhotoTrigger()
+{
+}
+
+AbstractPhotoTrigger::AbstractPhotoTrigger(QObject * parent)
+    : QObject(parent)
+{
+}
+
+namespace {
+
+void registerAbstractPhotoTriggerMetaType()
+{
+    qmlRegisterUncreatableType<AbstractPhotoTrigger>(
+        "QGroundControl.Controllers", 1, 0, "AbstractPhotoTrigger", "abstract");
+}
+
+}  // namespace
+
+Q_COREAPP_STARTUP_FUNCTION(registerAbstractPhotoTriggerMetaType);

--- a/src/PhotoGallery/AbstractPhotoTrigger.h
+++ b/src/PhotoGallery/AbstractPhotoTrigger.h
@@ -1,0 +1,60 @@
+/****************************************************************************
+ *
+ *   (c) 2019 QGROUNDCONTROL PROJECT <http://www.qgroundcontrol.org>
+ *
+ * QGroundControl is licensed according to the terms in the file
+ * COPYING.md in the root of the source code directory.
+ *
+ ****************************************************************************/
+
+#pragma once
+
+#include <QObject>
+
+/// A "photo" operation in progress
+///
+/// Represents a photo being taken. This object exists while this is in
+/// progress and can be used by callers to track operation.
+class AbstractPhotoTriggerOperation : public QObject {
+    Q_OBJECT
+public:
+    ~AbstractPhotoTriggerOperation() override;
+
+    virtual bool finished() const = 0;
+    /// Only meaningful in finished.
+    virtual bool success() const = 0;
+    /// Id of the photo, if operation succeeded.
+    virtual QString id() const = 0;
+
+signals:
+    /// Signal emitted when the operation has finished.
+    ///
+    /// This object is alive until after emitting this signal has finished, it
+    /// must not be referenced after delivery of this signal has completed.
+    void finish();
+};
+
+/// Abstract interface to trigger taking a photo.
+class AbstractPhotoTrigger : public QObject {
+    Q_OBJECT
+public:
+    ~AbstractPhotoTrigger() override;
+
+    explicit AbstractPhotoTrigger(QObject * parent = nullptr);
+
+    /// Take a photo.
+    ///
+    /// \returns Operation in progress or nullptr.
+    ///
+    /// Starts taking a photo. If no photo can presently be taken at all
+    /// (e.g. no camera) then this may return nullptr to indicate failure.
+    /// Otherwise, returns a continuation object to represent the operation in
+    /// progress.
+    ///
+    /// The continuation object is alive for as long as the operation is in
+    /// progress, up and until its "finish" signal has been emitted.
+    ///
+    /// This method should also ensure that the operation cannot delay
+    /// "indefinitely" (but e.g. instead cancel after some timeout).
+    virtual AbstractPhotoTriggerOperation * takePhoto() = 0;
+};

--- a/src/PhotoGallery/AsyncDownloadPhotoTrigger.cc
+++ b/src/PhotoGallery/AsyncDownloadPhotoTrigger.cc
@@ -1,0 +1,155 @@
+/****************************************************************************
+ *
+ *   (c) 2019 QGROUNDCONTROL PROJECT <http://www.qgroundcontrol.org>
+ *
+ * QGroundControl is licensed according to the terms in the file
+ * COPYING.md in the root of the source code directory.
+ *
+ ****************************************************************************/
+
+#include "AsyncDownloadPhotoTrigger.h"
+
+#include <QNetworkReply>
+
+#include "PhotoFileStore.h"
+
+AsyncDownloadPhotoTriggerOperation::~AsyncDownloadPhotoTriggerOperation()
+{
+}
+
+bool AsyncDownloadPhotoTriggerOperation::finished() const
+{
+    return _finished;
+}
+bool AsyncDownloadPhotoTriggerOperation::success() const
+{
+    return _success;
+}
+
+QString AsyncDownloadPhotoTriggerOperation::id() const
+{
+    return _id;
+}
+
+void AsyncDownloadPhotoTriggerOperation::finishSuccess(QString id)
+{
+    _finished = true;
+    _success = true;
+    _id = std::move(id);
+    emit finish();
+    delete this;
+}
+
+void AsyncDownloadPhotoTriggerOperation::finishFailure()
+{
+    _finished = true;
+    _success = false;
+    emit finish();
+    delete this;
+}
+
+AsyncDownloadPhotoTrigger::~AsyncDownloadPhotoTrigger()
+{
+    failPhotoOperation();
+}
+
+AsyncDownloadPhotoTrigger::AsyncDownloadPhotoTrigger(
+    std::function<bool()> photo_trigger_fn,
+    const Config & config,
+    PhotoFileStore * store ,
+    QObject * parent)
+    : AbstractPhotoTrigger(parent),
+      _photo_trigger_fn(std::move(photo_trigger_fn)),
+      _config(config)
+{
+    _photo_timeout.setSingleShot(true);
+    connect(&_photo_timeout, SIGNAL(timeout()), this, SLOT(failPhotoOperation()));
+    connect(&_download_manager, SIGNAL(finished(QNetworkReply*)), this, SLOT(downloadFinished(QNetworkReply*)));
+    if (store) {
+        setStore(store);
+    }
+}
+
+AsyncDownloadPhotoTriggerOperation * AsyncDownloadPhotoTrigger::takePhoto()
+{
+    if (_store && !_active_op) {
+        if (_photo_trigger_fn()) {
+            _active_op = new AsyncDownloadPhotoTriggerOperation();
+            _photo_timeout.start(_config.photo_timeout / std::chrono::milliseconds(1));
+            return _active_op;
+        } else {
+            return nullptr;
+        }
+    } else {
+        return nullptr;
+    }
+}
+
+PhotoFileStore * AsyncDownloadPhotoTrigger::store() const
+{
+    return _store;
+}
+
+void AsyncDownloadPhotoTrigger::setStore(PhotoFileStore * store)
+{
+    failPhotoOperation();
+    _store = store;
+}
+
+
+void AsyncDownloadPhotoTrigger::completePhotoWithURI(const QString & uri)
+{
+    // We can be called in two different scenarios:
+    // - Photo was triggered through "takePhoto" API function: In this case
+    //   there must be an active operation, but no download yet (because
+    //   we would otherwise already have initiated download). Initiate download
+    //   and track it.
+    // - "Unsolicited": Some photo was taken, but we did not ask for it. In
+    //   the latter case, also initiate download, but do not bother tracking.
+    if (_active_op && !_active_reply) {
+        _active_reply = _download_manager.get(QNetworkRequest(QUrl(uri)));
+        // NB: QNetworkReply has progress signals, could pass that on.
+    } else {
+        _download_manager.get(QNetworkRequest(QUrl(uri)));
+    }
+}
+
+void AsyncDownloadPhotoTrigger::completePhotoFailed()
+{
+    // See comments to completePhotoWithURI regarding this notification.
+    if (_active_op && !_active_reply) {
+        failPhotoOperation();
+    }
+}
+
+void AsyncDownloadPhotoTrigger::failPhotoOperation()
+{
+    if (_active_op) {
+        _active_op->finishFailure();
+        _active_op = nullptr;
+    }
+    if (_active_reply) {
+        _active_reply->abort();
+        _active_reply = nullptr;
+    }
+}
+
+void AsyncDownloadPhotoTrigger::downloadFinished(QNetworkReply * reply)
+{
+    if (reply == _active_reply) {
+        if (reply->error()) {
+            _active_op->finishFailure();
+        } else {
+            QByteArray data = reply->readAll();
+            QString id = _store->add(reply->url().fileName(), std::move(data));
+            _active_op->finishSuccess(id);
+        }
+        _active_op = nullptr;
+        _active_reply = nullptr;
+    } else {
+        if (!reply->error()) {
+            QByteArray data = reply->readAll();
+            QString id = _store->add(reply->url().fileName(), std::move(data));
+        }
+    }
+}

--- a/src/PhotoGallery/AsyncDownloadPhotoTrigger.h
+++ b/src/PhotoGallery/AsyncDownloadPhotoTrigger.h
@@ -1,0 +1,155 @@
+/****************************************************************************
+ *
+ *   (c) 2019 QGROUNDCONTROL PROJECT <http://www.qgroundcontrol.org>
+ *
+ * QGroundControl is licensed according to the terms in the file
+ * COPYING.md in the root of the source code directory.
+ *
+ ****************************************************************************/
+
+#pragma once
+
+#include <QNetworkAccessManager>
+#include <QObject>
+#include <QTimer>
+
+#include "AbstractPhotoTrigger.h"
+
+class AsyncDownloadPhotoTrigger;
+class PhotoFileStore;
+
+
+/// A "photo" operation in progress
+///
+/// Represents a photo being taken. This object exists while this is in
+/// progress.
+class AsyncDownloadPhotoTriggerOperation final : public AbstractPhotoTriggerOperation {
+    Q_OBJECT
+public:
+    ~AsyncDownloadPhotoTriggerOperation() override;
+
+    bool finished() const override;
+    bool success() const override;
+    QString id() const override;
+
+private:
+    bool _finished = false;
+    bool _success = false;
+    QString _id;
+
+    /// This operation has succeeded in taking a photo.
+    ///
+    /// \param id The id by which it was put into the store
+    ///
+    /// Called by the controller to conclude this operation. Sets state, emits
+    /// signal and destroys this object afterwards.
+    void finishSuccess(QString id);
+
+    /// This operation has failed.
+    ///
+    /// Called by the controller to conclude this operation. Sets state, emits
+    /// signal and destroys this object afterwards.
+    void finishFailure();
+
+    friend class AsyncDownloadPhotoTrigger;
+};
+
+/// Take a photo by async helper and download.
+///
+/// Take a photo by invoking a (parameter-less) asynchronous helper. The trigger
+///function is parameterizable to allow injecting either the trigger to
+/// mavlink camera (for real integration), or a mock (for testing).
+class AsyncDownloadPhotoTrigger final : public AbstractPhotoTrigger {
+    Q_OBJECT
+    Q_PROPERTY(PhotoFileStore* store READ store WRITE setStore)
+public:
+    class Config {
+    public:
+        /// Timeout for photo
+        ///
+        /// Defines the time between initiating a photo and the time we expect
+        /// the response back. If it takes longer than this, taking the photo
+        /// is declared to have failed.
+        std::chrono::system_clock::duration photo_timeout = std::chrono::seconds(5);
+    };
+
+    ~AsyncDownloadPhotoTrigger() override;
+
+    /// Construct photo trigger object
+    ///
+    /// \param photo_trigger_fn Function to be called to start taking photo
+    /// \param config Configuration
+    /// \param store (Optional) the data store where photos are pushed to
+    /// \param parent Qt parent object for memory management
+    AsyncDownloadPhotoTrigger(
+        std::function<bool()> photo_trigger_fn,
+        const Config & config,
+        PhotoFileStore * store = nullptr,
+        QObject * parent = nullptr);
+
+    /// Take a photo.
+    ///
+    /// \returns Operation in progress or nullptr.
+    ///
+    /// Starts taking a photo. If no photo can presently be taken at all
+    /// (e.g. no camera) then this may return nullptr to indicate failure.
+    /// Otherwise, returns a continuation object to represent the operation in
+    /// progress.
+    ///
+    /// The continuation object is alive for as long as the operation is in
+    /// progress, up and until its "finish" signal has been emitted.
+    AsyncDownloadPhotoTriggerOperation * takePhoto() override;
+
+    PhotoFileStore * store() const;
+    void setStore(PhotoFileStore * store);
+
+public slots:
+    /// External notice of completed photo operation
+    ///
+    /// Called from other system (mavlink camera handler) to indicate that a
+    /// photo has been taken. This tries correlates it with an operation
+    /// initiated through this interface.
+    void completePhotoWithURI(const QString & uri);
+
+    /// External notice of completed photo operation
+    ///
+    /// Called from other system (mavlink camera handler) to indicate that an
+    /// attempt to take a photo has failed. This tries to correlate it with
+    /// an operation initiated through this interface.
+    void completePhotoFailed();
+
+private slots:
+    /// Fail an operation started by "takePhoto".
+    void failPhotoOperation();
+
+    /// Callback issued when network download has completed.
+    void downloadFinished(QNetworkReply * reply);
+
+private:
+
+    /// Functional to trigger a photo
+    ///
+    /// Attempts to start taking a photo. If the attempt fails outright,
+    /// should return false. Otherwise, should return true to indicate
+    /// that an operation is in progress.
+    std::function<bool()> _photo_trigger_fn;
+
+    Config _config;
+
+    /// Store where to put acquired photos.
+    PhotoFileStore * _store = nullptr;
+
+    /// Currently  ongoing operation.
+    AsyncDownloadPhotoTriggerOperation * _active_op = nullptr;
+
+    /// Download for ongoing operation.
+    ///
+    /// Invariant: this may only be non-null if _active_op is non-null as well.
+    QNetworkReply * _active_reply = nullptr;
+
+    /// Timer to declare on overdue operation terminated.
+    QTimer _photo_timeout;
+
+    /// Manager for retrieval if images.
+    QNetworkAccessManager _download_manager;
+};

--- a/src/PhotoGallery/CMakeLists.txt
+++ b/src/PhotoGallery/CMakeLists.txt
@@ -1,0 +1,25 @@
+add_library(PhotoGallery
+    AbstractPhotoTrigger.cc
+    AsyncDownloadPhotoTrigger.cc
+    PhotoFileStore.cc
+    PhotoGalleryModel.cc
+    PhotoGalleryVehicleGlue.cc
+    PhotoGalleryView.cc
+)
+
+add_custom_target(
+    PhotoGalleryQml
+SOURCES
+    PhotoGalleryView.qml
+)
+
+target_link_libraries(PhotoGallery
+    PUBLIC
+        ui
+)
+
+target_include_directories(PhotoGallery
+    PUBLIC
+        ${CMAKE_CURRENT_SOURCE_DIR}
+    )
+

--- a/src/PhotoGallery/PhotoFileStore.cc
+++ b/src/PhotoGallery/PhotoFileStore.cc
@@ -1,0 +1,126 @@
+/****************************************************************************
+ *
+ *   (c) 2019 QGROUNDCONTROL PROJECT <http://www.qgroundcontrol.org>
+ *
+ * QGroundControl is licensed according to the terms in the file
+ * COPYING.md in the root of the source code directory.
+ *
+ ****************************************************************************/
+
+#include "PhotoFileStore.h"
+
+#include <QDateTime>
+#include <QDir>
+#include <QDebug>
+#include <QtQml>
+
+PhotoFileStore::PhotoFileStore(QObject * parent)
+    : QObject(parent)
+{
+}
+
+PhotoFileStore::PhotoFileStore(QString location, QObject * parent)
+    : PhotoFileStore(parent)
+{
+    setLocation(std::move(location));
+}
+
+void
+PhotoFileStore::setLocation(QString location)
+{
+    if (_location != location) {
+        _location = std::move(location);
+        rescan();
+    }
+}
+const QString & PhotoFileStore::location() const
+{
+    return _location;
+}
+
+const std::set<QString> & PhotoFileStore::ids() const
+{
+    return _photo_ids;
+}
+
+QString PhotoFileStore::add(QString name_hint, QByteArray data)
+{
+    if (_location.isEmpty()) {
+        return {};
+    }
+    QString id = name_hint;
+    while (_photo_ids.find(id) != _photo_ids.end()) {
+        QDateTime now = QDateTime::currentDateTime();
+        QString suffix = QFileInfo(name_hint).suffix();
+        id = now.toString("yyyy-MM-dd-HH-mm-ss.z");
+        if (!suffix.isEmpty()) {
+            id += "." + suffix;
+        }
+    }
+    QFile file(QDir(_location).filePath(id));
+    if (!file.open(QIODevice::ReadWrite | QIODevice::NewOnly)) {
+        return {};
+    }
+    if (file.write(data) != data.size()) {
+        file.remove();
+        return {};
+    }
+    file.close();
+
+    _photo_ids.insert(id);
+    emit added({id});
+
+    return id;
+}
+
+void PhotoFileStore::remove(const std::set<QString> & ids)
+{
+    if (_location.isEmpty()) {
+        return;
+    }
+    for (const auto & id : ids) {
+        _photo_ids.erase(id);
+        QFile file(QDir(_location).filePath(id));
+        file.remove();
+    }
+    emit removed(ids);
+}
+
+QVariant PhotoFileStore::read(const QString & id) const
+{
+    if (_location.isEmpty()) {
+        return {};
+    }
+    QFile file(QDir(_location).filePath(id));
+    if (!file.open(QIODevice::ReadOnly)) {
+        return {};
+    }
+
+    // XXX: reading file of arbitrary size into memory -- what could go wrong?
+    return file.readAll();
+}
+
+void PhotoFileStore::rescan()
+{
+    emit removed(_photo_ids);
+    _photo_ids.clear();
+    auto entries = QDir(_location).entryInfoList();
+    for (const auto & entry : entries) {
+        if (!entry.isFile()) {
+            continue;
+        }
+        _photo_ids.insert(entry.fileName());
+    }
+    emit added(_photo_ids);
+}
+
+namespace {
+
+void registerPhotoFileStoreMetaType()
+{
+    qmlRegisterType<PhotoFileStore>("QGroundControl.Controllers", 1, 0, "PhotoFileStore");
+}
+
+}  // namespace
+
+Q_COREAPP_STARTUP_FUNCTION(registerPhotoFileStoreMetaType);

--- a/src/PhotoGallery/PhotoFileStore.h
+++ b/src/PhotoGallery/PhotoFileStore.h
@@ -1,0 +1,88 @@
+/****************************************************************************
+ *
+ *   (c) 2019 QGROUNDCONTROL PROJECT <http://www.qgroundcontrol.org>
+ *
+ * QGroundControl is licensed according to the terms in the file
+ * COPYING.md in the root of the source code directory.
+ *
+ ****************************************************************************/
+
+#pragma once
+
+#include <QObject>
+
+#include <set>
+
+/// Represent photo collection stored on filesystem
+///
+/// Manages a collection of photos stored as files in some filesystem. It
+/// provides facilities to list, retrieve, add, modify and remove files. Its
+/// raison d'être is to
+/// - provide notifiers about changes to store such that* different actors can
+///   have a consistent view. (NB: does///not* imply thread synchronization --
+///   assuming to be accessed from main GUI thread only), and
+/// - manage assigning ids to incoming files
+///
+/// The store presently does not manage folders/sub-directories. This is a
+/// feature that could be added, although it might be preferrable from GUI
+/// perspective to use "tags" independent of physical storage location for
+/// grouping.
+///
+/// Another feature that is not fully clear whether this is the best place is
+/// synchronization with external storage -- might go here or elsewhere.
+class PhotoFileStore : public QObject {
+    Q_OBJECT
+    Q_PROPERTY(QString location READ location WRITE setLocation)
+
+public:
+    explicit PhotoFileStore(QObject * parent = nullptr);
+    explicit PhotoFileStore(QString location, QObject * parent = nullptr);
+
+    /// Adds photo to the store.
+    ///
+    /// \param name_hint Proposed internal id for photo (also, filename). There
+    /// is no guarantee that this name is going to be used, though.
+    /// \param data Raw photo data.
+    /// \returns ID of the photo stored, for later access.
+    ///
+    /// This adds a new photo to the store. The name given is taken as a hint
+    /// such that the resulting file has the same name as on the origin device
+    /// (simplifies diagnostics), but ultimately this may choose a new name
+    /// to avoid collisions and/or help with maintaining internal sorting.
+    QString add(QString name_hint, QByteArray data);
+
+    /// Gets list of photo ids held.
+    const std::set<QString> & ids() const;
+
+    /// Permanently erases photos from store.
+    ///
+    /// \param ids Identifiers of photos to be erased.
+    void remove(const std::set<QString> & ids);
+
+    /// Reads photo data.
+    ///
+    /// \param id Identifier of photo to be read.
+    ///
+    /// Reads data for the given photo from store. The returned QVariant will
+    /// contain a QByteArray if the read succeeded, or be empty otherwise.
+    /// Check via .canConvert<QByteArray> and access via .value<QByteArray>.
+    ///
+    /// Read failure should be considered as a "broken image".
+    QVariant read(const QString & id) const;
+
+    void setLocation(QString local_storage);
+    const QString & location() const;
+
+signals:
+    /// Notify of photos being added.
+    void added(const std::set<QString> & ids);
+    /// Notify of photos being deleted.
+    void removed(const std::set<QString> & ids);
+
+private:
+    /// Check filesystem whether any file added/removed.
+    void rescan();
+
+    QString _location;
+    std::set<QString> _photo_ids;
+};

--- a/src/PhotoGallery/PhotoGalleryModel.cc
+++ b/src/PhotoGallery/PhotoGalleryModel.cc
@@ -1,0 +1,150 @@
+/****************************************************************************
+ *
+ *   (c) 2019 QGROUNDCONTROL PROJECT <http://www.qgroundcontrol.org>
+ *
+ * QGroundControl is licensed according to the terms in the file
+ * COPYING.md in the root of the source code directory.
+ *
+ ****************************************************************************/
+
+#include "PhotoGalleryModel.h"
+
+#include <QImage>
+#include <QVariant>
+#include <QtQml>
+
+#include "PhotoFileStore.h"
+
+PhotoGalleryModel::~PhotoGalleryModel()
+{
+}
+
+PhotoGalleryModel::PhotoGalleryModel(PhotoFileStore * store, QObject * parent)
+    : PhotoGalleryModel(parent)
+{
+    setStore(store);
+}
+
+PhotoGalleryModel::PhotoGalleryModel(QObject * parent)
+    : QObject(parent), _cache(100)
+{
+}
+
+PhotoFileStore * PhotoGalleryModel::store() const
+{
+    return _store;
+}
+
+void PhotoGalleryModel::setStore(PhotoFileStore * store)
+{
+    clear();
+    _store = store;
+    if (_store) {
+        addedByStore(_store->ids());
+        connect(_store, &PhotoFileStore::added, this, &PhotoGalleryModel::addedByStore);
+        connect(_store, &PhotoFileStore::removed, this, &PhotoGalleryModel::removedByStore);
+    }
+}
+
+PhotoGalleryModel::Item PhotoGalleryModel::data(PhotoGalleryModelIndex index) const
+{
+    if (index < _ids.size()) {
+        const QString & id = _ids[index];
+        Item item;
+        item.id = id;
+        auto cached_item = _cache.object(id);
+        if (cached_item) {
+            item.image = *cached_item;
+        } else {
+            auto data = _store->read(id);
+            if (data.canConvert<QByteArray>()) {
+                auto ptr = std::make_shared<QImage>();
+                if (ptr->loadFromData(data.value<QByteArray>())) {
+                    _cache.insert(id, new std::shared_ptr<QImage>(ptr));
+                    item.image = std::move(ptr);
+                }
+            }
+        }
+        return item;
+    } else {
+        return {};
+    }
+}
+
+std::size_t PhotoGalleryModel::numPhotos() const
+{
+    return _ids.size();
+}
+
+void PhotoGalleryModel::remove(const std::set<QString> & ids)
+{
+    if (_store) {
+        _store->remove(ids);
+    }
+}
+
+
+void PhotoGalleryModel::addedByStore(const std::set<QString> & ids)
+{
+    std::set<PhotoGalleryModelIndex> indices_added;
+
+    // Yes this looks quite stupid, performing O(n^2) insertions into a vector
+    // in the worst case.
+    // This is however called in two ways only:
+    // - when store is empty: everything is filled in correct sequence, so it
+    //   it O(n) then
+    // - when taking new photo: in all likelihood, things are sorted by date
+    //   already so new image goes to end, meaning O(1). In rare circumstances,
+    //   it is O(n) if an image is put into the middle, but this is still not
+    //   worth worrying as we are not taking millions of pictures per second.
+    for (auto & id : ids) {
+        auto i = std::lower_bound(_ids.begin(), _ids.end(), id);
+        std::unique_ptr<Item> item(new Item);
+        i = _ids.insert(i, std::move(id));
+        indices_added.insert(i - _ids.begin());
+    }
+    emit added(indices_added);
+}
+
+void PhotoGalleryModel::removedByStore(const std::set<QString> & ids)
+{
+    std::set<PhotoGalleryModelIndex> indices_removed;
+    for (std::size_t n = _ids.size(); n > 0; --n) {
+        std::size_t index = n - 1;
+        if (ids.find(_ids[index]) != ids.end()) {
+            indices_removed.insert(PhotoGalleryModelIndex(index));
+            _cache.remove(_ids[index]);
+            _ids.erase(_ids.begin() + index);
+        }
+    }
+
+    emit removed(indices_removed);
+}
+
+void PhotoGalleryModel::clear()
+{
+    if (_store) {
+        disconnect(_store, &PhotoFileStore::added, this, &PhotoGalleryModel::addedByStore);
+        disconnect(_store, &PhotoFileStore::removed, this, &PhotoGalleryModel::removedByStore);
+    }
+    _cache.clear();
+    _ids.clear();
+    std::set<PhotoGalleryModelIndex> indices_removed;
+    for (std::size_t n = 0; n < _ids.size(); ++n) {
+        indices_removed.insert(PhotoGalleryModelIndex(n));
+    }
+
+    emit removed(indices_removed);
+}
+
+namespace {
+
+void registerPhotoFileStoreMetaType()
+{
+    // XXX: correct namespace
+    qmlRegisterType<PhotoGalleryModel>("QGroundControl.Controllers", 1, 0, "PhotoGalleryModel");
+}
+
+}  // namespace
+
+Q_COREAPP_STARTUP_FUNCTION(registerPhotoFileStoreMetaType);

--- a/src/PhotoGallery/PhotoGalleryModel.h
+++ b/src/PhotoGallery/PhotoGalleryModel.h
@@ -1,0 +1,93 @@
+/****************************************************************************
+ *
+ *   (c) 2019 QGROUNDCONTROL PROJECT <http://www.qgroundcontrol.org>
+ *
+ * QGroundControl is licensed according to the terms in the file
+ * COPYING.md in the root of the source code directory.
+ *
+ ****************************************************************************/
+
+#pragma once
+
+#include <memory>
+#include <set>
+#include <vector>
+
+#include <QCache>
+#include <QObject>
+
+class PhotoFileStore;
+
+/// Index into photo PhotoGalleryModel
+///
+/// Currently, photo gallery exposes a "flat" view of a list of images. This
+/// may change when introducing tags to group images by.
+///
+using PhotoGalleryModelIndex = std::size_t;
+
+/// Represent photo gallery data.
+///
+/// Represent all photos held in the gallery in a form suitable for manipulation
+/// through user interface. The fact that photos are stored as files and are
+/// binary data is abstracted away in this representations -- we are dealing
+/// with actual images, and the images also have a well-defined order.
+class PhotoGalleryModel : public QObject {
+    Q_OBJECT
+
+    Q_PROPERTY(PhotoFileStore* store READ store WRITE setStore);
+
+public:
+    struct Item {
+        QString id;
+        std::shared_ptr<const QImage> image;
+    };
+
+    ~PhotoGalleryModel() override;
+
+    explicit PhotoGalleryModel(PhotoFileStore * store, QObject * parent = nullptr);
+    explicit PhotoGalleryModel(QObject * parent = nullptr);
+
+    PhotoFileStore * store() const;
+    void setStore(PhotoFileStore * store);
+
+    /// Get item at index.
+    ///
+    /// \param index Index of element to access.
+    ///
+    /// Returns the item held for the given index, if any. Caller is expected
+    /// to check whether id is empty -- this indicates that no item of given
+    /// index exists.
+    Item data(PhotoGalleryModelIndex index) const;
+
+    /// Number of entries held.
+    std::size_t numPhotos() const;
+
+    /// Remove images by their ids.
+    void remove(const std::set<QString> & ids);
+
+signals:
+    /// Notify that indices are added.
+    void added(const std::set<PhotoGalleryModelIndex> & indices);
+    /// Notify that indices are removed.
+    void removed(const std::set<PhotoGalleryModelIndex> & indices);
+
+private slots:
+    /// Notification from data store that new photos have been added.
+    void addedByStore(const std::set<QString> & ids);
+
+    /// Notification from data store that photos have been deleted.
+    void removedByStore(const std::set<QString> & ids);
+
+private:
+    /// Delete all data in model.
+    void clear();
+
+    PhotoFileStore * _store = nullptr;
+    std::vector<QString> _ids;
+
+    /// Cache of images.
+    ///
+    /// Keep a bounded number of images in memory (avoid consuming all
+    /// memory in case we have a large number of images stored).
+    mutable QCache<QString, std::shared_ptr<QImage>> _cache;
+};

--- a/src/PhotoGallery/PhotoGalleryTests.cc
+++ b/src/PhotoGallery/PhotoGalleryTests.cc
@@ -1,0 +1,170 @@
+/****************************************************************************
+ *
+ *   (c) 2019 QGROUNDCONTROL PROJECT <http://www.qgroundcontrol.org>
+ *
+ * QGroundControl is licensed according to the terms in the file
+ * COPYING.md in the root of the source code directory.
+ *
+ ****************************************************************************/
+
+#include "PhotoFileStore.h"
+
+#include <QtTest/QtTest>
+
+#include <fcntl.h>
+#include <netinet/ip.h>
+#include <poll.h>
+#include <sys/types.h>
+#include <sys/socket.h>
+#include <unistd.h>
+
+#include <iostream>
+
+/* Test helpers. */
+
+namespace {
+
+void
+setFileContents(const QString & path, const QByteArray & contents)
+{
+    QFile file(path);
+    QVERIFY(file.open(QIODevice::ReadWrite | QIODevice::NewOnly));
+    QCOMPARE(contents.size(), file.write(contents));
+    file.close();
+}
+
+void
+verifyFileContents(const QString & path, const QByteArray & contents)
+{
+    QFile file(path);
+    QVERIFY(file.open(QIODevice::ReadOnly));
+    auto data = file.readAll();
+    QCOMPARE(data, contents);
+    file.close();
+}
+
+void
+verifyFileMissing(const QString & path)
+{
+    QFile file(path);
+    QVERIFY(!file.open(QIODevice::ReadOnly));
+}
+
+}  // namespace
+
+/* Actual tests. */
+
+class PhotoGalleryTests : public QObject {
+    Q_OBJECT
+
+private slots:
+    void testPhotoFileStoreFilesystem();
+    void testPhotoFileStoreNameCollisions();
+    void testPhotoFileStoreInitNotifications();
+    void testPhotoFileStoreRuntimeNotifications();
+};
+
+/// Verify photo store interacts correctly with filesystem.
+void PhotoGalleryTests::testPhotoFileStoreFilesystem()
+{
+    QTemporaryDir temp_dir;
+    QVERIFY(temp_dir.isValid());
+
+    setFileContents(temp_dir.filePath("foo.jpg"), "foo_content");
+    setFileContents(temp_dir.filePath("bar.jpg"), "bar_content");
+    PhotoFileStore store(temp_dir.path());
+
+    QCOMPARE(std::set<QString>({"bar.jpg", "foo.jpg"}), store.ids());
+
+    auto c = store.read("bar.jpg");
+    QVERIFY(c.canConvert<QByteArray>());
+    QCOMPARE(c.value<QByteArray>(), "bar_content");
+
+    auto id = store.add("baz.jpg", "baz_content");
+    QCOMPARE(id, "baz.jpg");
+    QCOMPARE(std::set<QString>({"bar.jpg", "baz.jpg", "foo.jpg"}), store.ids());
+
+    store.remove({"foo.jpg"});
+    QCOMPARE(std::set<QString>({"bar.jpg", "baz.jpg"}), store.ids());
+    verifyFileContents(temp_dir.filePath("bar.jpg"), "bar_content");
+    verifyFileContents(temp_dir.filePath("baz.jpg"), "baz_content");
+    verifyFileMissing(temp_dir.filePath("foo.jpg"));
+}
+
+/// Verify that names are kept if possible, but collisions are resolved.
+void PhotoGalleryTests::testPhotoFileStoreNameCollisions()
+{
+    QTemporaryDir temp_dir;
+    QVERIFY(temp_dir.isValid());
+
+    PhotoFileStore store(temp_dir.path());
+
+    auto foo_jpg = store.add("foo.jpg", "foo1");
+    QCOMPARE(foo_jpg, "foo.jpg");
+    auto foo2_jpg = store.add("foo.jpg", "foo2");
+    QVERIFY(foo2_jpg != foo_jpg);
+
+    QCOMPARE(std::set<QString>({foo_jpg, foo2_jpg}), store.ids());
+    QVERIFY(QRegularExpression("^.*\\.jpg$").match(foo2_jpg).hasMatch());
+    verifyFileContents(temp_dir.filePath(foo2_jpg), "foo2");
+}
+
+/// Verify observer is modified when store path is reconfigured.
+///
+/// This situation arises in the main program as the correct path is configured
+/// at runtime, after all models and views have been instantiated already.
+void PhotoGalleryTests::testPhotoFileStoreInitNotifications()
+{
+    PhotoFileStore store;
+
+    std::set<QString> added;
+    QObject::connect(
+        &store, &PhotoFileStore::added,
+        [&added](const std::set<QString> & ids) {
+            added.insert(ids.begin(), ids.end());
+        });
+    QCOMPARE(std::set<QString>(), added);
+
+    QTemporaryDir temp_dir;
+    QVERIFY(temp_dir.isValid());
+
+    setFileContents(temp_dir.filePath("foo.jpg"), "foo_content");
+    setFileContents(temp_dir.filePath("bar.jpg"), "bar_content");
+
+    store.setLocation(temp_dir.path());
+    QCOMPARE(std::set<QString>({"bar.jpg", "foo.jpg"}), store.ids());
+}
+
+/// Verify that notifications are sent when changing store.
+void PhotoGalleryTests::testPhotoFileStoreRuntimeNotifications()
+{
+    QTemporaryDir temp_dir;
+    QVERIFY(temp_dir.isValid());
+
+    PhotoFileStore store(temp_dir.path());
+    std::set<QString> added;
+    std::set<QString> removed;
+    QObject::connect(
+        &store, &PhotoFileStore::added,
+        [&added](const std::set<QString> & ids) {
+            added.insert(ids.begin(), ids.end());
+        });
+    QObject::connect(
+        &store, &PhotoFileStore::removed,
+        [&removed](const std::set<QString> & ids) {
+            removed.insert(ids.begin(), ids.end());
+        });
+
+    store.add("foo.jpg", "xxx");
+    QCOMPARE(std::set<QString>({"foo.jpg"}), added);
+    QCOMPARE(std::set<QString>(), removed);
+    added.clear();
+
+    store.remove({"foo.jpg"});
+    QCOMPARE(std::set<QString>(), added);
+    QCOMPARE(std::set<QString>({"foo.jpg"}), removed);
+
+}
+
+QTEST_MAIN(PhotoGalleryTests)
+#include "PhotoGalleryTests.moc"

--- a/src/PhotoGallery/PhotoGalleryTests.cc
+++ b/src/PhotoGallery/PhotoGalleryTests.cc
@@ -7,6 +7,7 @@
  *
  ****************************************************************************/
 
+#include "AsyncDownloadPhotoTrigger.h"
 #include "PhotoFileStore.h"
 
 #include <QtTest/QtTest>
@@ -23,6 +24,205 @@
 /* Test helpers. */
 
 namespace {
+
+/// Primitive http server.
+///
+/// Simple iterative webserver. Turned out to be fastest to just open-code.
+class MockHttpServer {
+public:
+    MockHttpServer()
+    {
+        int pipefds[2];
+        if (pipe2(pipefds, O_CLOEXEC) < 0) {
+            failStrError("pipe: ");
+        }
+        m_receive_exit_fd = pipefds[0];
+        m_notify_exit_fd = pipefds[1];
+
+        m_listen_fd = ::socket(AF_INET, SOCK_STREAM | SOCK_CLOEXEC, 0);
+        if (m_listen_fd < 0) {
+            failStrError("socket: ");
+        }
+
+        struct sockaddr_in addr;
+        addr.sin_family = AF_INET;
+        addr.sin_addr.s_addr = htonl(INADDR_LOOPBACK);
+        addr.sin_port = htons(0);
+        if (::bind(m_listen_fd, reinterpret_cast<struct sockaddr *>(&addr),
+                   sizeof(addr)) < 0) {
+            failStrError("bind: ");
+        }
+        socklen_t sl = sizeof(addr);
+        if (::getsockname(m_listen_fd,
+                          reinterpret_cast<struct sockaddr *>(&addr),
+                          &sl) < 0) {
+            failStrError("getsockname: ");
+        }
+        m_port = ntohs(addr.sin_port);
+        if (::listen(m_listen_fd, 50) < 0) {
+            failStrError("listen: ");
+        }
+
+        m_thread = std::thread([this]() {
+            runServer();
+        });
+    }
+
+    ~MockHttpServer()
+    {
+        char c = 'X';
+        ::write(m_notify_exit_fd, &c, sizeof(c));
+        m_thread.join();
+        ::close(m_listen_fd);
+    }
+
+    uint16_t port() const
+    {
+        return m_port;
+    }
+
+    QString getBaseURI() const
+    {
+        return "http://localhost:" + QString::number(port());
+    }
+
+    void setResponse(std::string uri, std::string response)
+    {
+        std::lock_guard<std::mutex> guard(m_lock);
+        m_responses.emplace(std::move(uri), std::move(response));
+    }
+
+    std::vector<std::string> getAndClearSeenRequestURIs()
+    {
+        std::lock_guard<std::mutex> guard(m_lock);
+        return std::move(m_seen_request_uris);
+    }
+
+private:
+    static void failStrError(const char * prefix)
+    {
+        QFAIL((prefix + std::string(strerror(errno))).c_str());
+    }
+
+    void runServer()
+    {
+        for (;;) {
+            struct pollfd pfds[2];
+            pfds[0].fd = m_receive_exit_fd;
+            pfds[0].events = POLLIN;
+            pfds[1].fd = m_listen_fd;
+            pfds[1].events = POLLIN;
+            ::poll(pfds, 2, -1);
+            if ((pfds[0].revents & POLLIN) == POLLIN) {
+                break;
+            }
+            if ((pfds[1].revents & POLLIN) == POLLIN) {
+                handleConnection();
+            }
+        }
+    }
+
+    void handleConnection()
+    {
+        int fd = ::accept4(m_listen_fd, nullptr, 0, SOCK_CLOEXEC);
+        if (fd < 0) {
+            failStrError("accept: ");
+        }
+
+        handleConnectionData(fd);
+
+        ::close(fd);
+    }
+
+    void handleConnectionData(int fd)
+    {
+        std::vector<char> buffer;
+        for (;;) {
+            if (std::find(buffer.begin(), buffer.end(), '\r') != buffer.end()) {
+                break;
+            }
+            size_t current_size = buffer.size();
+            buffer.resize(current_size + 1024);
+            ssize_t count = ::recv(fd, &buffer[current_size], 1024,
+                                   MSG_NOSIGNAL);
+            if (count <= 0) {
+                return;
+            }
+            buffer.resize(current_size + count);
+        }
+
+        auto endl = std::find(buffer.begin(), buffer.end(), '\r');
+        auto space1 = std::find(buffer.begin(), endl, ' ');
+        if (space1 == endl) {
+            return;
+        }
+
+        auto space2 = std::find(std::next(space1), endl, ' ');
+        if (space2 == endl) {
+            return;
+        }
+        std::string method(buffer.begin(), space1);
+        std::string uri(std::next(space1), space2);
+
+        std::string response;
+        if (method == "GET") {
+            std::lock_guard<std::mutex> guard(m_lock);
+            response = generateResponse(uri);
+            m_seen_request_uris.push_back(uri);
+        } else {
+            response = "HTTP/1.0 400 Bad request\r\nServer: localhost\r\n\r\n";
+        }
+
+        std::size_t sent = 0;
+        while (sent < response.size()) {
+            ssize_t count = ::send(fd, &response[sent], response.size() - sent,
+                                   MSG_NOSIGNAL);
+            if (count <= 0) {
+                return;
+            }
+            sent += count;
+        }
+    }
+
+    std::string generateResponse(const std::string & uri)
+    {
+        auto i = m_responses.find(uri);
+        return i == m_responses.end()
+               ? std::string("HTTP/1.0 404 Not found\r\n"
+                             "Server: localhost\r\n"
+                             "\r\n")
+               : i->second;
+    }
+
+    int m_listen_fd;
+    int m_notify_exit_fd;
+    int m_receive_exit_fd;
+    uint16_t m_port;
+    std::thread m_thread;
+    std::mutex m_lock;
+    std::map<std::string, std::string> m_responses;
+    std::vector<std::string> m_seen_request_uris;
+};
+
+std::string createJPEGImage(int width, int height)
+{
+    QImage image(width, height, QImage::Format_ARGB32);
+    QByteArray ba;
+    QBuffer buffer(&ba);
+    buffer.open(QIODevice::WriteOnly);
+    image.save(&buffer, "JPEG");
+    return std::string(ba.begin(), ba.end());
+}
+
+void verifyImage(const PhotoFileStore & store, const QString & id,
+                    int width, int height)
+{
+    auto data = store.read(id);
+    QVERIFY(data.canConvert<QByteArray>());
+    QImage image = QImage::fromData(data.value<QByteArray>());
+    QCOMPARE(image.width(), width);
+    QCOMPARE(image.height(), height);
+}
 
 void
 setFileContents(const QString & path, const QByteArray & contents)
@@ -62,6 +262,10 @@ private slots:
     void testPhotoFileStoreNameCollisions();
     void testPhotoFileStoreInitNotifications();
     void testPhotoFileStoreRuntimeNotifications();
+    void testPhotoTriggerDownloadSuccess();
+    void testPhotoTriggerAbortEarly();
+    void testPhotoTriggerDownloadFail();
+    void testPhotoUnsolicitedDownload();
 };
 
 /// Verify photo store interacts correctly with filesystem.
@@ -163,7 +367,151 @@ void PhotoGalleryTests::testPhotoFileStoreRuntimeNotifications()
     store.remove({"foo.jpg"});
     QCOMPARE(std::set<QString>(), added);
     QCOMPARE(std::set<QString>({"foo.jpg"}), removed);
+}
 
+/// Verify complete workflow of taking photo.
+///
+/// - Triggers taking a photo.
+/// - Downloads photo from source.
+/// - Puts it into store.
+/// - Verify that correct signals are emitted at every step.
+void PhotoGalleryTests::testPhotoTriggerDownloadSuccess()
+{
+    QTemporaryDir temp_dir;
+    QVERIFY(temp_dir.isValid());
+    PhotoFileStore store(temp_dir.path());
+
+    MockHttpServer http;
+    http.setResponse(
+        "/foo.jpg", "HTTP/1.0 200 Ok\r\n"
+        "Content-Type: image/jpeg\r\n"
+        "\r\n" +
+        createJPEGImage(16, 16));
+
+    bool photo_triggered = false;
+
+    AsyncDownloadPhotoTrigger photo_trigger(
+        [&photo_triggered](){photo_triggered = true; return true; },
+        {},
+        &store);
+
+    auto op = photo_trigger.takePhoto();
+    QVERIFY(photo_triggered);
+    QVERIFY(!op->finished());
+
+    bool notified_completion = false;
+    QObject::connect(
+        op, &AbstractPhotoTriggerOperation::finish,
+        [&notified_completion, op]() {
+            notified_completion = true;
+            QVERIFY(op->finished());
+            QVERIFY(op->success());
+            QCOMPARE(op->id(), "foo.jpg");
+        });
+
+    photo_trigger.completePhotoWithURI(http.getBaseURI() + "/foo.jpg");
+    while (!notified_completion) {
+        QTest::qWait(10);
+    }
+
+    verifyImage(store, "foo.jpg", 16, 16);
+}
+
+/// Verify that taking photo can be rejected by backend
+///
+/// Triggers taking a photo, reports failure.
+void PhotoGalleryTests::testPhotoTriggerAbortEarly()
+{
+    QTemporaryDir temp_dir;
+    QVERIFY(temp_dir.isValid());
+    PhotoFileStore store(temp_dir.path());
+
+    AsyncDownloadPhotoTrigger photo_trigger(
+        [](){ return false; },
+        {},
+        &store);
+
+    auto op = photo_trigger.takePhoto();
+    QVERIFY(!op);
+}
+
+/// Verify workflow of taking photo, but failing download
+///
+/// - Triggers taking a photo.
+/// - Start download, but fails it.
+void PhotoGalleryTests::testPhotoTriggerDownloadFail()
+{
+    QTemporaryDir temp_dir;
+    QVERIFY(temp_dir.isValid());
+    PhotoFileStore store(temp_dir.path());
+
+    MockHttpServer http;
+    bool photo_triggered = false;
+
+    AsyncDownloadPhotoTrigger photo_trigger(
+        [&photo_triggered](){photo_triggered = true; return true; },
+        {},
+        &store);
+
+    auto op = photo_trigger.takePhoto();
+    QVERIFY(photo_triggered);
+    QVERIFY(!op->finished());
+
+    bool notified_completion = false;
+    QObject::connect(
+        op, &AbstractPhotoTriggerOperation::finish,
+        [&notified_completion, op]() {
+            notified_completion = true;
+            QVERIFY(op->finished());
+            QVERIFY(!op->success());
+        });
+
+    photo_trigger.completePhotoWithURI(http.getBaseURI() + "/foo.jpg");
+    while (!notified_completion) {
+        QTest::qWait(10);
+    }
+}
+
+/// Verify that "unsolicited" photos are still processed.
+///
+/// - Receive notification that photo has been taken (without having requested
+///   it before).
+/// - Downloads photo from source.
+/// - Puts it into store.
+/// - Verify that correct signals are emitted at every step.
+void PhotoGalleryTests::testPhotoUnsolicitedDownload()
+{
+    QTemporaryDir temp_dir;
+    QVERIFY(temp_dir.isValid());
+    PhotoFileStore store(temp_dir.path());
+
+    MockHttpServer http;
+    http.setResponse(
+        "/foo.jpg", "HTTP/1.0 200 Ok\r\n"
+        "Content-Type: image/jpeg\r\n"
+        "\r\n" +
+        createJPEGImage(16, 16));
+
+    bool photo_triggered = false;
+
+    AsyncDownloadPhotoTrigger photo_trigger(
+        [&photo_triggered](){photo_triggered = true; return true; },
+        {},
+        &store);
+
+    std::set<QString> added;
+    QObject::connect(
+        &store, &PhotoFileStore::added,
+        [&added](const std::set<QString> & ids) {
+            added.insert(ids.begin(), ids.end());
+        });
+
+    photo_trigger.completePhotoWithURI(http.getBaseURI() + "/foo.jpg");
+    while (added.empty()) {
+        QTest::qWait(10);
+    }
+
+    verifyImage(store, "foo.jpg", 16, 16);
 }
 
 QTEST_MAIN(PhotoGalleryTests)

--- a/src/PhotoGallery/PhotoGalleryVehicleGlue.cc
+++ b/src/PhotoGallery/PhotoGalleryVehicleGlue.cc
@@ -1,0 +1,143 @@
+/****************************************************************************
+ *
+ *   (c) 2019 QGROUNDCONTROL PROJECT <http://www.qgroundcontrol.org>
+ *
+ * QGroundControl is licensed according to the terms in the file
+ * COPYING.md in the root of the source code directory.
+ *
+ ****************************************************************************/
+
+#include "PhotoGalleryVehicleGlue.h"
+
+#include "AbstractPhotoTrigger.h"
+#include "AsyncDownloadPhotoTrigger.h"
+#include "MultiVehicleManager.h"
+#include "PhotoFileStore.h"
+#include "QGCCameraManager.h"
+#include "Vehicle.h"
+
+PhotoGalleryVehicleGlue::~PhotoGalleryVehicleGlue()
+{
+}
+
+PhotoGalleryVehicleGlue::PhotoGalleryVehicleGlue(QObject * parent)
+    : QObject(parent),
+        _trigger(new AsyncDownloadPhotoTrigger(
+            [this] () {return triggerPhoto(); },
+            AsyncDownloadPhotoTrigger::Config{}, nullptr, this))
+{
+}
+
+AbstractPhotoTrigger* PhotoGalleryVehicleGlue::trigger() const
+{
+    return _trigger.get();
+}
+
+MultiVehicleManager* PhotoGalleryVehicleGlue::multiVehicleManager() const
+{
+    return _multi_vehicle_manager;
+}
+
+void PhotoGalleryVehicleGlue::setMultiVehicleManager(MultiVehicleManager* manager)
+{
+    // We assume that having a new MultiVehicleManager means that the old one
+    // is destroyed, as well as all vehicles and cameras transitively attached
+    // to it, and that this severes all connections we have established so
+    // far.
+    _vehicle_infos.clear();
+    _multi_vehicle_manager = manager;
+    if (_multi_vehicle_manager) {
+        connect(
+            _multi_vehicle_manager, &MultiVehicleManager::vehicleAdded,
+            this, &PhotoGalleryVehicleGlue::addVehicle);
+        connect(
+            _multi_vehicle_manager, &MultiVehicleManager::vehicleRemoved,
+            this, &PhotoGalleryVehicleGlue::removeVehicle);
+    }
+}
+
+PhotoFileStore* PhotoGalleryVehicleGlue::store() const
+{
+    return _trigger->store();
+}
+
+void PhotoGalleryVehicleGlue::setStore(PhotoFileStore * store)
+{
+    _trigger->setStore(store);
+}
+
+void PhotoGalleryVehicleGlue::addVehicle(Vehicle * vehicle)
+{
+    _vehicle_infos.push_back(VehicleInfo{ vehicle, nullptr });
+    connect(
+        vehicle, &Vehicle::dynamicCamerasChanged,
+        this,
+        [this, vehicle] () {
+            vehicleCameraManagerChanged(vehicle);
+        });
+    vehicleCameraManagerChanged(vehicle);
+
+}
+
+void PhotoGalleryVehicleGlue::removeVehicle(Vehicle * vehicle)
+{
+    auto i = findVehicle(vehicle);
+    if (i == _vehicle_infos.end()) {
+        return;
+    }
+    _vehicle_infos.erase(i);
+}
+
+void PhotoGalleryVehicleGlue::vehicleCameraManagerChanged(Vehicle * vehicle)
+{
+    auto i = findVehicle(vehicle);
+    if (i == _vehicle_infos.end()) {
+        return;
+    }
+    VehicleInfo& vehicle_info = *i;
+
+    QGCCameraManager* camera_manager = vehicle->dynamicCameras();
+    vehicle_info.camera_manager = camera_manager;
+
+    connect(
+        camera_manager, &QGCCameraManager::imageCaptured,
+        _trigger.get(), &AsyncDownloadPhotoTrigger::completePhotoWithURI);
+    connect(
+        camera_manager, &QGCCameraManager::imageCaptureFailure,
+        _trigger.get(), &AsyncDownloadPhotoTrigger::completePhotoFailed);
+}
+
+PhotoGalleryVehicleGlue::VehicleInfos::iterator PhotoGalleryVehicleGlue::findVehicle(Vehicle * vehicle)
+{
+    return std::find_if(
+        _vehicle_infos.begin(), _vehicle_infos.end(),
+        [vehicle](const VehicleInfo& info){ return info.vehicle == vehicle; });
+}
+
+bool PhotoGalleryVehicleGlue::triggerPhoto()
+{
+    for (const auto & vehicle_info : _vehicle_infos) {
+        QGCCameraManager* camera_manager = vehicle_info.camera_manager;
+        if (!camera_manager) {
+            continue;
+        }
+        QGCCameraControl* camera = camera_manager->currentCameraInstance();
+        if (!camera) {
+            continue;
+        }
+        camera->takePhoto();
+        return true;
+    }
+    return false;
+}
+
+namespace {
+
+void registerPhotoGalleryVehicleGlueMetaType()
+{
+    qmlRegisterType<PhotoGalleryVehicleGlue>("QGroundControl.Controllers", 1, 0, "PhotoGalleryVehicleGlue");
+}
+
+}  // namespace
+
+Q_COREAPP_STARTUP_FUNCTION(registerPhotoGalleryVehicleGlueMetaType);

--- a/src/PhotoGallery/PhotoGalleryVehicleGlue.h
+++ b/src/PhotoGallery/PhotoGalleryVehicleGlue.h
@@ -1,0 +1,85 @@
+/****************************************************************************
+ *
+ *   (c) 2019 QGROUNDCONTROL PROJECT <http://www.qgroundcontrol.org>
+ *
+ * QGroundControl is licensed according to the terms in the file
+ * COPYING.md in the root of the source code directory.
+ *
+ ****************************************************************************/
+
+#pragma once
+
+#include <list>
+#include <memory>
+
+#include <QObject>
+
+class AbstractPhotoTrigger;
+class AsyncDownloadPhotoTrigger;
+class MultiVehicleManager;
+class PhotoFileStore;
+class QGCCameraManager;
+class Vehicle;
+
+/// Bridging code to interface photo gallery with rest of QGCC
+///
+/// Provides the bridging between the cameras (attached to vehicles, discovered
+/// and managed by QGC code) and the photo gallery functionality which is
+/// otherwise fully isolated.
+///
+/// An instance of this class is created through the QML code and wired to the
+/// internal QGC bits.
+class PhotoGalleryVehicleGlue : public QObject {
+    Q_OBJECT
+
+    Q_PROPERTY(AbstractPhotoTrigger* trigger READ trigger);
+    Q_PROPERTY(MultiVehicleManager* manager READ multiVehicleManager WRITE setMultiVehicleManager);
+    Q_PROPERTY(PhotoFileStore* store READ store WRITE setStore);
+
+public:
+    ~PhotoGalleryVehicleGlue() override;
+
+    explicit PhotoGalleryVehicleGlue(QObject * parent = nullptr);
+
+    AbstractPhotoTrigger* trigger() const;
+    MultiVehicleManager* multiVehicleManager() const;
+    void setMultiVehicleManager(MultiVehicleManager* manager);
+    PhotoFileStore* store() const;
+    void setStore(PhotoFileStore* store);
+
+public slots:
+    /// Connected to vehicle manager to detect new vehicles connecting.
+    void addVehicle(Vehicle* vehicle);
+
+    /// Connected to vehicle manager to detect vehicles disconnecting.
+    void removeVehicle(Vehicle* vehicle);
+
+private:
+    struct VehicleInfo {
+        Vehicle* vehicle;
+        QGCCameraManager* camera_manager;
+    };
+    using VehicleInfos = std::list<VehicleInfo>;
+
+    /// Camera manager on vehicle changed.
+    ///
+    /// \param vehicle The vehicle affected.
+    void vehicleCameraManagerChanged(Vehicle * vehicle);
+
+    /// Find vehicle info in data structure.
+    ///
+    /// \param vehicle The vehicle requested.
+    ///
+    /// Returns iterator to vehicle info, or end() if not found.
+    VehicleInfos::iterator findVehicle(Vehicle * vehicle);
+
+    /// Triggers taking a photo.
+    ///
+    /// Tries to start taking a photo using one of the vehicles attached.
+    bool triggerPhoto();
+
+    std::unique_ptr<AsyncDownloadPhotoTrigger> _trigger;
+    MultiVehicleManager* _multi_vehicle_manager = nullptr;
+
+    VehicleInfos _vehicle_infos;
+};

--- a/src/PhotoGallery/PhotoGalleryView.cc
+++ b/src/PhotoGallery/PhotoGalleryView.cc
@@ -1,0 +1,780 @@
+/****************************************************************************
+ *
+ *   (c) 2019 QGROUNDCONTROL PROJECT <http://www.qgroundcontrol.org>
+ *
+ * QGroundControl is licensed according to the terms in the file
+ * COPYING.md in the root of the source code directory.
+ *
+ ****************************************************************************/
+
+#include "PhotoGalleryView.h"
+
+#include <QPainter>
+#include <QtQml>
+
+#include <cmath>
+
+#include "AbstractPhotoTrigger.h"
+
+namespace {
+
+void interpolateTransform(QTransform & t, double z)
+{
+    t.setMatrix(
+        t.m11() * z + 1 - z, t.m12() * z, t.m13() * z,
+        t.m21() * z, t.m22() * z + 1 - z, t.m23() * z,
+        t.m31() * z, t.m32() * z, t.m33() * z + 1 - z);
+}
+
+QRectF trashCanBounds(const QSizeF & view_bounds)
+{
+    double scale = std::min(view_bounds.width(), view_bounds.height()) * 0.1;
+    return QRectF(scale * 0.4, view_bounds.height() - scale * 1.4, scale, scale);
+}
+
+void drawTrashCan(QPainter * painter, const QRectF & bounds)
+{
+    double w = bounds.width();
+    double h = bounds.height();
+
+    QPainterPath path;
+    path.moveTo(0.00 * w, 0.05 * h);
+    path.lineTo(0.45 * w, 0.05 * h);
+    path.lineTo(0.45 * w, 0.00 * h);
+    path.lineTo(0.55 * w, 0.00 * h);
+    path.lineTo(0.55 * w, 0.05 * h);
+    path.lineTo(1.00 * w, 0.05 * h);
+    path.lineTo(1.00 * w, 0.20 * h);
+    path.lineTo(0.00 * w, 0.20 * h);
+    path.closeSubpath();
+    path.moveTo(0.00 * w, 0.25 * h);
+    path.lineTo(1.00 * w, 0.25 * h);
+    path.lineTo(1.00 * w, 1.00 * h);
+    path.lineTo(0.00 * w, 1.00 * h);
+    path.closeSubpath();
+    path.translate(bounds.left(), bounds.top());
+    painter->fillPath(path, Qt::white);
+    painter->setPen(QPen(Qt::black, w * 0.025, Qt::SolidLine, Qt::FlatCap, Qt::MiterJoin));
+    painter->drawPath(path);
+}
+
+QRectF exitZoomBounds(const QSizeF & view_bounds)
+{
+    double scale = std::min(view_bounds.width(), view_bounds.height()) * 0.1;
+    return QRectF(scale * 0.4, scale * 0.4, scale, scale);
+}
+
+void drawExitZoom(QPainter * painter, const QRectF & bounds)
+{
+    double w = bounds.width();
+    double h = bounds.height();
+
+    QPainterPath path;
+    path.moveTo(0.1 * w, 0.0 * h);
+    path.lineTo(0.5 * w, 0.4 * h);
+    path.lineTo(0.9 * w, 0.0 * h);
+    path.lineTo(1.0 * w, 0.1 * h);
+    path.lineTo(0.6 * w, 0.5 * h);
+    path.lineTo(1.0 * w, 0.9 * h);
+    path.lineTo(0.9 * w, 1.0 * h);
+    path.lineTo(0.5 * w, 0.6 * h);
+    path.lineTo(0.1 * w, 1.0 * h);
+    path.lineTo(0.0 * w, 0.9 * h);
+    path.lineTo(0.4 * w, 0.5 * h);
+    path.lineTo(0.0 * w, 0.1 * h);
+    path.closeSubpath();
+    path.translate(bounds.left(), bounds.top());
+    painter->fillPath(path, Qt::white);
+    painter->setPen(QPen(Qt::black, w * 0.025, Qt::SolidLine, Qt::FlatCap, Qt::MiterJoin));
+    painter->drawPath(path);
+}
+
+QRectF cameraTriggerBounds(const QSizeF & view_bounds)
+{
+    double scale = std::min(view_bounds.width(), view_bounds.height()) * 0.1;
+    return QRectF(view_bounds.width() - scale * 1.4, view_bounds.height() - scale * 1.4, scale, scale);
+}
+
+void drawCameraTrigger(QPainter * painter, const QRectF & bounds)
+{
+    double w = bounds.width();
+    double h = bounds.height();
+
+    QPainterPath path;
+    path.moveTo(0.00 * w, 0.20 * h);
+    path.lineTo(0.40 * w, 0.20 * h);
+    path.lineTo(0.45 * w, 0.15 * h);
+    path.lineTo(0.55 * w, 0.15 * h);
+    path.lineTo(0.60 * w, 0.20 * h);
+    path.lineTo(1.00 * w, 0.20 * h);
+    path.lineTo(1.00 * w, 0.80 * h);
+    path.lineTo(0.00 * w, 0.80 * h);
+    path.closeSubpath();
+    path.addEllipse(QRectF(0.4 * w, 0.4 * h, 0.2 * w, 0.2 * h));
+    path.translate(bounds.left(), bounds.top());
+    painter->fillPath(path, Qt::white);
+    painter->setPen(QPen(Qt::black, w * 0.025, Qt::SolidLine, Qt::FlatCap, Qt::MiterJoin));
+    painter->drawPath(path);
+}
+
+}  // namespace
+
+class PhotoGalleryView::InteractionState {
+public:
+    virtual ~InteractionState() {}
+
+    class Pan;
+    class Zoom;
+};
+
+class PhotoGalleryView::InteractionState::Pan final : public PhotoGalleryView::InteractionState {
+public:
+    virtual ~Pan() {}
+
+    /// Start location
+    ///
+    /// Start of pan in screen coordinates (i.e. the point on screen where mouse
+    /// started dragging / finger started panning).
+    QPointF start;
+
+    /// Start time
+    std::chrono::system_clock::time_point start_time;
+
+    /// Current location
+    ///
+    /// Current pan position (i.e. where mouse/finger moved to) in screen
+    /// coordinates.
+    QPointF current;
+
+    /// Cumulative distance travelled.
+    double distance_travelled = 0.0;
+};
+
+class PhotoGalleryView::InteractionState::Zoom final : public PhotoGalleryView::InteractionState {
+public:
+    virtual ~Zoom() {}
+
+    /// Zoom center point
+    ///
+    /// The center point of the zoom (i.e. the center point of the finger pinch
+    /// or the center point of where mouse scroll started).
+    QPointF center;
+
+    /// Change in zoom
+    double delta = 0.0;
+};
+
+PhotoGalleryView::PhotoGalleryView(QQuickItem * parent)
+    : QQuickPaintedItem(parent)
+{
+    setAcceptedMouseButtons(Qt::AllButtons);
+    _zoom_timeout.setSingleShot(true);
+    connect(&_zoom_timeout, &QTimer::timeout, this, &PhotoGalleryView::handleZoomTimeout);
+    _long_click_timeout.setSingleShot(true);
+    connect(&_long_click_timeout, &QTimer::timeout, this, &PhotoGalleryView::handleLongClickTimeout);
+
+    _view_state.mode = ViewMode::Gallery;
+    _view_state.gallery.offset = 0.0;
+    _view_state.gallery.columns = 4;
+}
+
+PhotoGalleryView::~PhotoGalleryView()
+{
+}
+
+void PhotoGalleryView::paintGallery(QPainter * painter, const QSizeF & bounds, const GalleryViewState & view) const
+{
+    int num_photos = _model->numPhotos();
+
+    QSizeF cell_dims = computeCellSize(bounds, view.columns);
+
+    int start_row = std::floor(view.offset);
+    int start_index = start_row * view.columns;
+    int end_index = start_index + std::ceil(bounds.height() / cell_dims.height() + 1) * view.columns;
+
+    bool any_selected = !_selected_images.empty();
+
+    int n = start_index;
+    while (n < num_photos && n < end_index) {
+        const auto & item = _model->data(PhotoGalleryModelIndex(n));
+        if (item.image) {
+            const auto & image = *item.image;
+            QRectF dst = imageIndexToScreen(view, bounds, n);
+            paintImageThumbnail(painter, image, dst,
+                any_selected ? (_selected_images.find(item.id) != _selected_images.end() ? SelectionState::Selected : SelectionState::Deselected) : SelectionState::None
+            );
+        }
+        ++n;
+    }
+}
+
+void PhotoGalleryView::paintSingle(QPainter * painter, const QSizeF & bounds, const SingleViewState & view) const
+{
+    const auto & item = _model->data(PhotoGalleryModelIndex(view.index));
+    if (!item.image) {
+        return;
+    }
+    const auto & image = *item.image;
+    QRect img_bounds = image.rect();
+    double img_aspect = static_cast<double>(img_bounds.width()) / img_bounds.height();
+    double view_aspect = bounds.width() / bounds.height();
+    double base_scale = (img_aspect > view_aspect) ? (img_bounds.width() / bounds.width()) : (img_bounds.height() / bounds.height());
+
+    QRectF src(0, 0, image.width(), image.height());
+    QRectF dst(bounds.width() / 2 - image.width() / base_scale / 2,  bounds.height() / 2 - image.height() / base_scale / 2, image.width() / base_scale, image.height() / base_scale);
+    painter->drawImage(dst, image, src);
+}
+
+void PhotoGalleryView::paint(QPainter * painter, const QSizeF & bounds, const ViewState & view) const
+{
+    switch (view.mode) {
+        case ViewMode::Gallery: {
+            paintGallery(painter, bounds, view.gallery);
+            break;
+        }
+        case ViewMode::Single: {
+            paintSingle(painter, bounds, view.single);
+            break;
+        }
+    }
+}
+
+void PhotoGalleryView::paintIcons(QPainter * painter, const QSizeF & bounds, const ViewState & view) const
+{
+    switch (view.mode) {
+        case ViewMode::Gallery: {
+            if (!_selected_images.empty()) {
+                drawTrashCan(painter, trashCanBounds(bounds));
+            }
+            drawCameraTrigger(painter, cameraTriggerBounds(bounds));
+            break;
+        }
+        case ViewMode::Single: {
+            drawExitZoom(painter, exitZoomBounds(bounds));
+            break;
+        }
+    }
+}
+
+void PhotoGalleryView::paintImageThumbnail(
+    QPainter * painter, const QImage & image, const QRectF & dst_bounds, SelectionState selection_state) const
+{
+    QRect img_bounds = image.rect();
+    // Figure out how to scale image into the view bounds.
+    double img_aspect = static_cast<double>(img_bounds.width()) / img_bounds.height();
+    double dst_aspect = dst_bounds.width() / dst_bounds.height();
+
+    double scale = (img_aspect > dst_aspect) ? (dst_bounds.height() / img_bounds.height()) : (dst_bounds.width() / img_bounds.width());
+
+    double crop_w = img_bounds.width() - dst_bounds.width() / scale;
+    double crop_h = img_bounds.height() - dst_bounds.height() / scale;
+    QRectF src(crop_w * 0.5, crop_h * 0.5, img_bounds.width() - crop_w, img_bounds.height() - crop_h);
+    painter->drawImage(dst_bounds, image, src);
+
+    if (selection_state == SelectionState::None) {
+        return;
+    }
+
+    auto box_scale = std::min(dst_bounds.width(), dst_bounds.height()) * 0.08;
+
+    QRectF select_box(dst_bounds.right() - 4 * box_scale,
+                     dst_bounds.top() + 1 * box_scale,
+                     3 * box_scale,
+                     3 * box_scale);
+    if (selection_state == SelectionState::Selected) {
+        painter->fillRect(select_box, Qt::green);
+    } else {
+        painter->fillRect(select_box, Qt::black);
+    }
+    painter->setPen(QPen(Qt::white, box_scale * 0.4, Qt::SolidLine, Qt::FlatCap, Qt::MiterJoin));
+    painter->drawRect(select_box);
+}
+
+void PhotoGalleryView::paint(QPainter * painter)
+{
+    QRectF rect(0, 0, width(), height());
+    painter->fillRect(rect, QColor("black"));
+    if (!_model) {
+        return;
+    }
+
+    if (!_interaction_state) {
+        paint(painter, rect.size(), _view_state);
+        paintIcons(painter, rect.size(), _view_state);
+    } else {
+        ViewState current_view_state = _view_state;
+        ViewState floating_view_state = _view_state;
+        applyInteraction(_interaction_state.get(), current_view_state, InteractionApplyMode::FloatingBase);
+        applyInteraction(_interaction_state.get(), floating_view_state, InteractionApplyMode::FloatingOverlay);
+
+        if (!needInterpolation(current_view_state, floating_view_state)) {
+            paint(painter, rect.size(), current_view_state);
+            paintIcons(painter, rect.size(), current_view_state);
+        } else {
+            double z = computeInterpolationPosition(_interaction_state.get());
+            QTransform t1;
+            QTransform t2;
+            std::tie(t1, t2) = computeInterpolationTransforms(rect.size(), current_view_state, floating_view_state, _interaction_state.get());
+
+            interpolateTransform(t1, z);
+            interpolateTransform(t2, 1 - z);
+
+            QImage tmp(width(), height(), QImage::Format_ARGB32);
+            QPainter tmp_p(&tmp);
+
+            tmp_p.setCompositionMode(QPainter::CompositionMode_Source);
+            tmp_p.fillRect(0, 0, width(), height(), QColor(Qt::transparent));
+            paint(&tmp_p, rect.size(), current_view_state);
+            painter->setOpacity(1 - z);
+            painter->setTransform(t1);
+            painter->drawImage(0, 0, tmp);
+
+            tmp_p.fillRect(0, 0, width(), height(), QColor(Qt::transparent));
+            paint(&tmp_p, rect.size(), floating_view_state);
+            painter->setOpacity(z);
+            painter->setTransform(t2);
+            painter->drawImage(0, 0, tmp);
+        }
+    }
+}
+
+void PhotoGalleryView::setModel(PhotoGalleryModel * model)
+{
+    _model = model;
+    connect(model, &PhotoGalleryModel::added, this, &PhotoGalleryView::modelAdded);
+    connect(model, &PhotoGalleryModel::removed, this, &PhotoGalleryView::modelRemoved);
+}
+
+PhotoGalleryModel * PhotoGalleryView::model() const
+{
+    return _model;
+}
+
+AbstractPhotoTrigger * PhotoGalleryView::trigger() const
+{
+    return _trigger;
+}
+
+void PhotoGalleryView::setTrigger(AbstractPhotoTrigger * trigger)
+{
+    _trigger = trigger;
+}
+
+void PhotoGalleryView::mousePressEvent(QMouseEvent * event)
+{
+    if (event->button() == Qt::LeftButton) {
+        event->accept();
+
+        commitInteraction();
+
+        std::unique_ptr<InteractionState::Pan> pan(new InteractionState::Pan());
+        pan->start = QPointF(event->x(), event->y());
+        pan->start_time = std::chrono::system_clock::now();
+        pan->current = pan->start;
+        _interaction_state = std::move(pan);
+        _long_click_timeout.start(_parameters.long_click_timeout / std::chrono::milliseconds(1));
+    }
+}
+
+void PhotoGalleryView::mouseReleaseEvent(QMouseEvent * event)
+{
+    if (event->button() == Qt::LeftButton) {
+        event->accept();
+        _long_click_timeout.stop();
+
+        auto * pan = dynamic_cast<InteractionState::Pan *>(_interaction_state.get());
+        if (pan) {
+            double ds = pan->distance_travelled;
+            commitInteraction();
+            if (ds < _parameters.click_slip) {
+                handleShortClick(QPointF(event->x(), event->y()));
+            }
+        }
+    }
+}
+
+void PhotoGalleryView::mouseMoveEvent(QMouseEvent * event)
+{
+    auto * pan = dynamic_cast<InteractionState::Pan *>(_interaction_state.get());
+    if (pan) {
+        event->accept();
+
+        pan->current = QPointF(event->x(), event->y());
+        double dx = (pan->current.x() - pan->start.x());
+        double dy = (pan->current.y() - pan->start.y());
+        double ds = sqrt(dx * dx + dy * dy) / std::max(width(), height());
+        pan->distance_travelled += ds;
+        update();
+    }
+}
+
+void PhotoGalleryView::wheelEvent(QWheelEvent *event)
+{
+    event->accept();
+
+    InteractionState::Zoom * zoom = dynamic_cast<InteractionState::Zoom *>(_interaction_state.get());
+    if (_interaction_state && !zoom) {
+        commitInteraction();
+        _interaction_state.reset();
+    }
+    if (!zoom) {
+        zoom = new InteractionState::Zoom();
+        _interaction_state.reset(zoom);
+        zoom->center = QPointF(event->x(), event->y());
+    }
+
+    zoom->delta -= event->angleDelta().y() / (90. * 8.);
+    update();
+    _zoom_timeout.start(_parameters.zoom_timeout / std::chrono::milliseconds(1));
+}
+
+QSizeF PhotoGalleryView::computeCellSize(const QSizeF & bounds, int num_columns) const
+{
+    double w = bounds.width() / num_columns;
+    return {w, w / _parameters.grid_aspect};
+}
+
+void PhotoGalleryView::handleZoomTimeout()
+{
+    if (dynamic_cast<InteractionState::Zoom *>(_interaction_state.get())) {
+        commitInteraction();
+    }
+}
+
+void PhotoGalleryView::handleLongClickTimeout()
+{
+    if (auto * pan = dynamic_cast<InteractionState::Pan *>(_interaction_state.get())) {
+        double ds = pan->distance_travelled;
+        QPointF where(pan->current);
+        if (ds < _parameters.click_slip) {
+            commitInteraction();
+            handleLongClick(where);
+        }
+    }
+}
+
+void PhotoGalleryView::modelAdded(const std::set<PhotoGalleryModelIndex> & /*indices*/)
+{
+    update();
+}
+
+void PhotoGalleryView::modelRemoved(const std::set<PhotoGalleryModelIndex> & /*indices*/)
+{
+    update();
+}
+
+
+namespace {
+
+/// Find stop in vector
+///
+/// Find place in vector where our current column configuration lives (or the
+/// one closest to it, at least. Unless the input vector is empty (don't do
+/// that!) this will always yield a valid iterator into the vector.
+std::vector<int>::const_iterator findCurrentColumnStop(const std::vector<int> & stops, int ncolumns)
+{
+    auto i = stops.begin();
+    for (auto j = stops.begin(); j != stops.end(); ++j) {
+        if (*j <= ncolumns) {
+            i = j;
+        }
+    }
+    return i;
+}
+
+/// Find prev/next stop
+///
+/// Find upper/lower column configuration, from our current configuration. Unless
+/// stops is empty (don't do that!) this either yields an iterator to the next
+/// column configuration to use, or iterator to stops.end() to indicate that we
+/// should switch to single image view mode.
+std::vector<int>::const_iterator findNextColumnStop(const std::vector<int> & stops, int columns, int direction)
+{
+    auto i = findCurrentColumnStop(stops, columns);
+    if (i == stops.end()) {
+        return i;
+    }
+
+    if (direction == -1) {
+        if (i != stops.begin()) {
+            return std::prev(i);
+        } else {
+            return stops.end();
+        }
+    }
+    if (direction == +1 && std::next(i) != stops.end()) {
+        return std::next(i);
+    }
+    return i;
+}
+
+}
+
+void PhotoGalleryView::applyInteraction(const InteractionState * interaction, ViewState & view, InteractionApplyMode mode)
+{
+    if (auto pan = dynamic_cast<const InteractionState::Pan *>(interaction)) {
+        QSizeF bounds(width(), height());
+        switch (view.mode) {
+            case ViewMode::Gallery: {
+                QSizeF cell_dims = computeCellSize(bounds, view.gallery.columns);
+                double delta = (pan->start.y() - pan->current.y()) / cell_dims.height();
+                view.gallery.offset = std::max(0.0, view.gallery.offset + delta);
+                boundGalleryViewOffset(bounds, view.gallery);
+                break;
+            }
+            case ViewMode::Single: {
+                break;
+            }
+        }
+    } else if (auto zoom = dynamic_cast<const InteractionState::Zoom *>(interaction)) {
+        QSizeF bounds(width(), height());
+        bool threshold =
+            (mode == InteractionApplyMode::Normal && std::fabs(zoom->delta) > 0.5) ||
+            (mode == InteractionApplyMode::FloatingOverlay && zoom->delta != 0.0);
+        switch (view.mode) {
+            case ViewMode::Gallery: {
+                if (threshold) {
+                    int index = screenToImageIndex(view.gallery, bounds, zoom->center);
+                    auto i = findNextColumnStop(_parameters.column_stops, view.gallery.columns, zoom->delta > 0 ? +1 : -1);
+                    if (i == (_parameters.column_stops.end())) {
+                        if (index >= 0 && index < imageIndexLimit()) {
+                            view.mode = ViewMode::Single;
+                            view.single.index = index;
+                        }
+                    } else {
+                        QRectF original = imageIndexToScreen(view.gallery, bounds, index);
+                        view.gallery.columns = *i;
+                        QRectF zoomed = imageIndexToScreen(view.gallery, bounds, index);
+                        view.gallery.offset += (zoomed.y() - original.y()) / computeCellSize(bounds, view.gallery.columns).height();
+                        boundGalleryViewOffset(bounds, view.gallery);
+                    }
+                }
+                break;
+            }
+            case ViewMode::Single: {
+                if (threshold && zoom->delta > 0) {
+                    view.mode = ViewMode::Gallery;
+                }
+                break;
+            }
+        }
+    }
+}
+
+void PhotoGalleryView::commitInteraction()
+{
+    applyInteraction(_interaction_state.get(), _view_state);
+    update();
+    _interaction_state.reset();
+}
+
+void PhotoGalleryView::handleLongClick(const QPointF & where)
+{
+    if (_view_state.mode == ViewMode::Gallery) {
+        if (!_selected_images.empty() && trashCanBounds(size()).contains(where)) {
+            if (_model) {
+                _model->remove(_selected_images);
+            }
+            _selected_images.clear();
+            return;
+        }
+        if (cameraTriggerBounds(size()).contains(where)) {
+            if (_trigger) {
+                _trigger->takePhoto();
+            }
+            return;
+        }
+        toggleSelectImageAt(_view_state.gallery, where);
+    }
+}
+
+void PhotoGalleryView::handleShortClick(const QPointF & where)
+{
+    if (_view_state.mode == ViewMode::Gallery) {
+        if (!_selected_images.empty() && trashCanBounds(size()).contains(where)) {
+            return;
+        }
+        if (cameraTriggerBounds(size()).contains(where)) {
+            if (_trigger) {
+                _trigger->takePhoto();
+            }
+            return;
+        }
+        if (!_selected_images.empty()) {
+            toggleSelectImageAt(_view_state.gallery, where);
+        } else {
+            magnifyImageAt(_view_state.gallery, where);
+        }
+    } else {
+        if (exitZoomBounds(size()).contains(where)) {
+            _view_state.mode = ViewMode::Gallery;
+            update();
+            return;
+        }
+    }
+}
+
+QRectF PhotoGalleryView::imageIndexToScreen(const GalleryViewState & view, const QSizeF & bounds, int index) const
+{
+    QSizeF cell_size = computeCellSize(bounds, view.columns);
+    int x = index % view.columns;
+    int y = index / view.columns;
+    return QRectF(QPointF(x * cell_size.width(), (y - view.offset) * cell_size.height()), cell_size);
+}
+
+int PhotoGalleryView::screenToImageIndex(const GalleryViewState & view, const QSizeF & bounds, const QPointF & point) const
+{
+    QSizeF cell_size = computeCellSize(bounds, view.columns);
+    int x = floor(point.x() / cell_size.width());
+    int y = floor(point.y() / cell_size.height() + view.offset);
+    return x + y * view.columns;
+}
+
+int PhotoGalleryView::imageIndexLimit() const
+{
+    return _model ? _model->numPhotos() : 0;
+}
+
+void PhotoGalleryView::boundGalleryViewOffset(const QSizeF & bounds, GalleryViewState & view) const
+{
+    QSizeF cell_size = computeCellSize(bounds, view.columns);
+    int last_row = (imageIndexLimit() - 1) / view.columns + 1;
+    double upper_limit = last_row - bounds.height() / cell_size.height();
+    view.offset = std::max(0.0, std::min(upper_limit, view.offset));
+}
+
+bool PhotoGalleryView::needInterpolation(const ViewState & view_1, const ViewState & view_2)
+{
+    if (view_1.mode != view_2.mode) {
+        return true;
+    }
+    if (view_1.mode == ViewMode::Gallery) {
+        return view_1.gallery.columns != view_2.gallery.columns;
+    }
+    return false;
+}
+
+double PhotoGalleryView::computeInterpolationPosition(const InteractionState * interaction)
+{
+    if (auto zoom = dynamic_cast<const InteractionState::Zoom *>(interaction)) {
+        return std::min(1.0, std::fabs(zoom->delta));
+    }
+    return 0.0;
+}
+
+std::pair<QTransform, QTransform>
+PhotoGalleryView::computeInterpolationTransforms(const QSizeF & bounds, const ViewState & view_1, const ViewState & view_2, const InteractionState * interaction)
+{
+    QTransform t1;
+    QTransform t2;
+    QPointF center(0, 0);
+    if (auto zoom = dynamic_cast<const InteractionState::Zoom *>(interaction)) {
+        center = zoom->center;
+    }
+    if (view_1.mode == ViewMode::Gallery && view_2.mode == ViewMode::Gallery) {
+        double scale = static_cast<double>(view_1.gallery.columns) / view_2.gallery.columns;
+        int index = screenToImageIndex(view_1.gallery, bounds, center);
+        double y1 = imageIndexToScreen(view_1.gallery, bounds, index).y();
+        double y2 = imageIndexToScreen(view_2.gallery, bounds, index).y();
+        t1.translate(0, y1);
+        t1.scale(scale, scale);
+        t1.translate(0, -y2);
+        t2.translate(0, y2);
+        t2.scale(1 / scale, 1 / scale);
+        t2.translate(0, -y1);
+    } else if (view_1.mode == ViewMode::Gallery && view_2.mode == ViewMode::Single) {
+        double image_aspect_ratio = getImageAspectRatio(view_2.single.index);
+        QRectF gallery_outline = thumbnailVirtualOutline(view_1.gallery, bounds, view_2.single.index, image_aspect_ratio);
+        QRectF single_outline = singleOutline(bounds, image_aspect_ratio);
+
+        t2.translate(gallery_outline.x(), gallery_outline.y());
+        t2.scale(gallery_outline.width() / single_outline.width(), gallery_outline.height() / single_outline.height());
+        t2.translate(-single_outline.x(), -single_outline.y());
+    } else if (view_1.mode == ViewMode::Single && view_2.mode == ViewMode::Gallery) {
+        double image_aspect_ratio = getImageAspectRatio(view_1.single.index);
+        QRectF gallery_outline = thumbnailVirtualOutline(view_2.gallery, bounds, view_1.single.index, image_aspect_ratio);
+        QRectF single_outline = singleOutline(bounds, image_aspect_ratio);
+
+        t1.translate(gallery_outline.x(), gallery_outline.y());
+        t1.scale(gallery_outline.width() / single_outline.width(), gallery_outline.height() / single_outline.height());
+        t1.translate(-single_outline.x(), -single_outline.y());
+    }
+
+    return {t1, t2};
+}
+
+QRectF PhotoGalleryView::thumbnailVirtualOutline(const GalleryViewState & view, const QSizeF & bounds, int index, double image_aspect_ratio) const
+{
+    QRectF box = imageIndexToScreen(view, bounds, index);
+    double thumbnail_aspect_ratio = box.width() / box.height();
+
+    if (image_aspect_ratio > thumbnail_aspect_ratio) {
+        double w = box.height() * image_aspect_ratio;
+        box = QRectF(box.x() - 0.5 * (w - box.width()), box.y(), w, box.height());
+    } else {
+        double h = box.width() / image_aspect_ratio;
+        box = QRectF(box.x(), box.y() - 0.5 * (h - box.height()), box.width(), h);
+    }
+
+    return box;
+}
+
+QRectF PhotoGalleryView::singleOutline(const QSizeF & bounds, double image_aspect_ratio) const
+{
+    double view_aspect_ratio = bounds.width() / bounds.height();
+    if (view_aspect_ratio > image_aspect_ratio) {
+        double w = bounds.height() * image_aspect_ratio;
+        return QRectF(0.5 * (bounds.width() - w), 0, w, bounds.height());
+    } else {
+        double h = bounds.width() / image_aspect_ratio;
+        return QRectF(0, 0.5 * (bounds.height() - h), bounds.width(), h);
+    }
+}
+
+double PhotoGalleryView::getImageAspectRatio(int index) const
+{
+    const auto & item = _model->data(PhotoGalleryModelIndex(index));
+    if (item.image) {
+        const auto & image = *item.image;
+        return static_cast<double>(image.rect().width()) / image.rect().height();
+    } else {
+        return 1.0;
+    }
+}
+
+void PhotoGalleryView::toggleSelectImageAt(const GalleryViewState & view, const QPointF & point)
+{
+    int index = screenToImageIndex(view, size(), point);
+    const auto & item = _model->data(PhotoGalleryModelIndex(index));
+    if (!item.id.isEmpty()) {
+        auto i = _selected_images.find(item.id);
+        if (i == _selected_images.end()) {
+            _selected_images.insert(item.id);
+        } else {
+            _selected_images.erase(item.id);
+        }
+        update();
+    }
+}
+
+void PhotoGalleryView::magnifyImageAt(const GalleryViewState & view, const QPointF & point)
+{
+    int index = screenToImageIndex(view, size(), point);
+    const auto & item = _model->data(PhotoGalleryModelIndex(index));
+    if (!item.id.isEmpty()) {
+        _view_state.mode = ViewMode::Single;
+        _view_state.single.index = index;
+        update();
+    }
+}
+
+namespace {
+
+void registerPhotoGalleryMetaType()
+{
+    qmlRegisterType<PhotoGalleryView>("QGroundControl.Controllers", 1, 0, "PhotoGalleryView");
+}
+
+}  // namespace
+
+Q_COREAPP_STARTUP_FUNCTION(registerPhotoGalleryMetaType);

--- a/src/PhotoGallery/PhotoGalleryView.h
+++ b/src/PhotoGallery/PhotoGalleryView.h
@@ -1,0 +1,255 @@
+/****************************************************************************
+ *
+ *   (c) 2019 QGROUNDCONTROL PROJECT <http://www.qgroundcontrol.org>
+ *
+ * QGroundControl is licensed according to the terms in the file
+ * COPYING.md in the root of the source code directory.
+ *
+ ****************************************************************************/
+
+#pragma once
+
+#include <memory>
+
+#include <QColor>
+#include <QIcon>
+#include <QQuickPaintedItem>
+#include <QTimer>
+
+#include "PhotoGalleryModel.h"
+
+class AbstractPhotoTrigger;
+
+/// Widget for image gallery.
+class PhotoGalleryView : public QQuickPaintedItem
+{
+    Q_OBJECT
+
+    Q_PROPERTY(PhotoGalleryModel* model READ model WRITE setModel);
+    Q_PROPERTY(AbstractPhotoTrigger* trigger READ trigger WRITE setTrigger);
+public:
+    /// Customizations of the widget
+    struct Parameters {
+        /// Grid cell aspect ration.
+        ///
+        /// Defines the aspect ratio of the cells shown in the image gallery
+        /// grid. Android gallery uses 1.0 in minimum magnification, but maybe
+        /// something close to "actual" image aspect makes more sense for better
+        /// screen space utilization?
+        double grid_aspect = 4.0/3.0;
+
+        /// Columns shown in magnification.
+        ///
+        /// Defines the number of columns that we can show the gallery overview
+        /// with.
+        /// Requirements:
+        /// - must be non-empty
+        /// - first entry must be > 1
+        /// - sorted in ascending order
+        std::vector<int> column_stops = {2, 4, 6};
+
+        /// Slip allowed to consider panning a "click" actually.
+        ///
+        /// Moving pointer by less than this amount (relative to widget size)
+        /// is interpreted as being a "click".
+        double click_slip = 0.02;
+
+        /// Timeout to finish zoom operations.
+        std::chrono::system_clock::duration zoom_timeout = std::chrono::milliseconds(250);
+
+        /// Timeout to recognize long clicks.
+        std::chrono::system_clock::duration long_click_timeout = std::chrono::milliseconds(500);
+    };
+
+    /// Current view mode (gallery or single image full screen).
+    enum class ViewMode {
+        /// Show gallery organized as grid
+        Gallery = 0,
+        /// Show single image full screen
+        Single = 1
+    };
+
+    /// Detail state for "single" view mode.
+    struct SingleViewState {
+        /// Identify image currently shown
+        int index;
+    };
+
+    /// Detail state for "gallery" view mode.
+    struct GalleryViewState {
+        /// Number of columns shown
+        int columns;
+
+        /// Vertical view offset
+        ///
+        /// The top edge of view as fractional row position in the image grid.
+        /// If this is 0.0, then the top edge of the view is at the top edge
+        /// of the first row (1.0 the second image etc.).
+        /// If this is 0.5 then the top edge of the view as half-way in the
+        /// first row etc.
+        double offset;
+    };
+
+    /// Current visual state.
+    ///
+    /// This defines the complete visual state that is shown on screen, except
+    /// for an "unstable" overlay view that is used to animate between different
+    /// states.
+    struct ViewState {
+        /// View mode: gallery grid or single image
+        ViewMode mode;
+
+        /// Detail state for gallery view mode
+        GalleryViewState gallery;
+
+        /// Detail state for single image view mode
+        SingleViewState single;
+    };
+
+    explicit PhotoGalleryView(QQuickItem *parent = nullptr);
+    ~PhotoGalleryView() override;
+
+    void setModel(PhotoGalleryModel * model);
+    PhotoGalleryModel * model() const;
+
+    AbstractPhotoTrigger * trigger() const;
+    void setTrigger(AbstractPhotoTrigger * trigger);
+
+    void paint(QPainter *painter) override;
+
+    void mousePressEvent(QMouseEvent * event) override;
+    void mouseReleaseEvent(QMouseEvent * event) override;
+    void mouseMoveEvent(QMouseEvent * event) override;
+    void wheelEvent(QWheelEvent *event) override;
+
+private slots:
+    /// Handle timeout for zoom operation.
+    void handleZoomTimeout();
+
+    /// Handle timeout to detect very long clicks.
+    void handleLongClickTimeout();
+
+    void modelAdded(const std::set<PhotoGalleryModelIndex> & indices);
+    void modelRemoved(const std::set<PhotoGalleryModelIndex> & indices);
+
+private:
+    /// Control how view changes should be applied
+    enum class InteractionApplyMode {
+        /// Change view based on user interaction state
+        ///
+        /// Apply (final) interaction state to view. This "snaps" to thresholds
+        /// as needed.
+        Normal = 0,
+        /// Apply changes for base of floating view
+        ///
+        /// When making user interactions that show an intermediate state
+        /// between present an (possible) target state, apply changes to form
+        /// the "base" view.
+        FloatingBase = 1,
+        /// Apply changes for overlay of floating view
+        ///
+        /// When making user interactions that show an intermediate state
+        /// between present an (possible) target state, apply changes to form
+        /// the "overlay" view.
+        FloatingOverlay = 2,
+    };
+    enum class SelectionState {
+        Deselected = 0,
+        Selected = 1,
+        None = 2
+    };
+    class InteractionState;
+
+    /// Paints gallery of images.
+    void paintGallery(QPainter * painter, const QSizeF & bounds, const GalleryViewState & view) const;
+
+    /// Paints single full-screen image.
+    void paintSingle(QPainter * painter, const QSizeF & bounds, const SingleViewState & view) const;
+
+    /// Paints view in given view mode (gallery or single).
+    void paint(QPainter * painter, const QSizeF & bounds, const ViewState & view) const;
+
+    /// Paints icons appropriate for current view mode.
+    void paintIcons(QPainter * painter, const QSizeF & bounds, const ViewState & view) const;
+
+    /// Paints "thumbnailed" version of image.
+    ///
+    /// Paint image thumbnail into the given target area. The image is cropped
+    /// to fill the space in the target area (top/bottom or left/right depending
+    /// on aspect ratio).
+    void paintImageThumbnail(
+        QPainter * painter, const QImage & image,
+        const QRectF & dst_bounds, SelectionState selection_state) const;
+
+    QSizeF computeCellSize(const QSizeF & bounds, int num_columns) const;
+
+    void applyInteraction(
+        const InteractionState * interaction,
+        ViewState & view,
+        InteractionApplyMode mode = InteractionApplyMode::Normal);
+
+    /// Set new view state resulting from user interaction.
+    ///
+    /// Zoom/pan operations show an intermediate state of how the widget view
+    /// is transformed. This snaps the actual view mode to the target view mode.
+    void commitInteraction();
+
+    void handleLongClick(const QPointF & where);
+
+    void handleShortClick(const QPointF & where);
+
+    /// Upper bound to valid image index
+    int imageIndexLimit() const;
+    void boundGalleryViewOffset(const QSizeF & bounds, GalleryViewState & view) const;
+
+    /// Screen position of image
+    ///
+    /// Compute logical location on screen where picture of given index would
+    /// appear.
+    QRectF imageIndexToScreen(const GalleryViewState & view, const QSizeF & bounds, int index) const;
+    int screenToImageIndex(const GalleryViewState & view, const QSizeF & bounds, const QPointF & point) const;
+
+    static bool needInterpolation(const ViewState & view_1, const ViewState & view_2);
+    static double computeInterpolationPosition(const InteractionState * interaction);
+
+    std::pair<QTransform, QTransform>
+    computeInterpolationTransforms(const QSizeF & bounds, const ViewState & view_1, const ViewState & view_2, const InteractionState * interaction);
+
+    QRectF thumbnailVirtualOutline(const GalleryViewState & view, const QSizeF & bounds, int index, double image_aspect_ratio) const;
+
+    QRectF singleOutline(const QSizeF & bounds, double image_aspect_ratio) const;
+
+    double getImageAspectRatio(int index) const;
+
+    void toggleSelectImageAt(const GalleryViewState & view, const QPointF & point);
+
+    void magnifyImageAt(const GalleryViewState & view, const QPointF & point);
+
+    Parameters _parameters;
+
+    PhotoGalleryModel * _model = nullptr;
+
+    AbstractPhotoTrigger * _trigger = nullptr;
+
+    ViewState _view_state;
+
+    /// On-going user interaction state
+    ///
+    /// This models the "unstable" state of a user interaction (e.g. dragging /
+    /// panning / zooming in progress).
+    std::unique_ptr<InteractionState> _interaction_state;
+
+    /// Timeout for zoom interaction.
+    ///
+    /// This timer is used as a helper to terminate zoom interaction (we
+    /// lack an event of "releasing scroll wheel").
+    QTimer _zoom_timeout;
+
+    /// Click timeout.
+    ///
+    /// This timer is used as a helper to distinguish "long click" and "pan"
+    /// operations.
+    QTimer _long_click_timeout;
+
+    std::set<QString> _selected_images;
+};

--- a/src/PhotoGallery/PhotoGalleryView.qml
+++ b/src/PhotoGallery/PhotoGalleryView.qml
@@ -1,0 +1,25 @@
+import QtQuick 2.6
+import QtQuick.Controls 2.0
+
+import QGroundControl.Controllers   1.0
+import QGroundControl               1.0
+
+PhotoGalleryView {
+    property PhotoFileStore store : PhotoFileStore {
+        id: photoFileStore
+        objectName: "PhotoFileStore"
+        location: QGroundControl.settingsManager.appSettings.photoSavePath
+    }
+    property PhotoGalleryVehicleGlue glue : PhotoGalleryVehicleGlue {
+        objectName: "PhotoGalleryVehicleGlue"
+        manager: QGroundControl.multiVehicleManager
+        store: photoFileStore
+    }
+    model : PhotoGalleryModel {
+        id: photoGalleryModel
+        objectName: "PhotoGalleryModel"
+        store: photoFileStore
+    }
+    trigger : glue.trigger
+    objectName: "PhotoGalleryView"
+}

--- a/src/PhotoGallery/photogallery.pri
+++ b/src/PhotoGallery/photogallery.pri
@@ -1,0 +1,12 @@
+# This includes the files that can be compiled hermetically (independent of
+# remainder of QGC, and split out to allow unit tests) as well as those
+# that cannot.
+
+include($$PWD/photogallery_hermetic.pri)
+
+SOURCES += \
+    $$PWD/PhotoGalleryVehicleGlue.cc \
+
+HEADERS += \
+    $$PWD/PhotoGalleryVehicleGlue.h \
+

--- a/src/PhotoGallery/photogallery_hermetic.pri
+++ b/src/PhotoGallery/photogallery_hermetic.pri
@@ -1,0 +1,10 @@
+# PhotoGallery modules that can be built hermetically (i.e. those that are not
+# dependent on the remainder of QGC).
+
+QT += network qml quick
+
+SOURCES += \
+    $$PWD/PhotoFileStore.cc \
+
+HEADERS += \
+    $$PWD/PhotoFileStore.h \

--- a/src/PhotoGallery/photogallery_hermetic.pri
+++ b/src/PhotoGallery/photogallery_hermetic.pri
@@ -8,9 +8,11 @@ SOURCES += \
     $$PWD/AsyncDownloadPhotoTrigger.cc \
     $$PWD/PhotoFileStore.cc \
     $$PWD/PhotoGalleryModel.cc \
+    $$PWD/PhotoGalleryView.cc \
 
 HEADERS += \
     $$PWD/AbstractPhotoTrigger.h \
     $$PWD/AsyncDownloadPhotoTrigger.h \
     $$PWD/PhotoFileStore.h \
     $$PWD/PhotoGalleryModel.h \
+    $$PWD/PhotoGalleryView.h \

--- a/src/PhotoGallery/photogallery_hermetic.pri
+++ b/src/PhotoGallery/photogallery_hermetic.pri
@@ -4,7 +4,11 @@
 QT += network qml quick
 
 SOURCES += \
+    $$PWD/AbstractPhotoTrigger.cc \
+    $$PWD/AsyncDownloadPhotoTrigger.cc \
     $$PWD/PhotoFileStore.cc \
 
 HEADERS += \
+    $$PWD/AbstractPhotoTrigger.h \
+    $$PWD/AsyncDownloadPhotoTrigger.h \
     $$PWD/PhotoFileStore.h \

--- a/src/PhotoGallery/photogallery_hermetic.pri
+++ b/src/PhotoGallery/photogallery_hermetic.pri
@@ -7,8 +7,10 @@ SOURCES += \
     $$PWD/AbstractPhotoTrigger.cc \
     $$PWD/AsyncDownloadPhotoTrigger.cc \
     $$PWD/PhotoFileStore.cc \
+    $$PWD/PhotoGalleryModel.cc \
 
 HEADERS += \
     $$PWD/AbstractPhotoTrigger.h \
     $$PWD/AsyncDownloadPhotoTrigger.h \
     $$PWD/PhotoFileStore.h \
+    $$PWD/PhotoGalleryModel.h \

--- a/src/PhotoGallery/photogallerytest.pro
+++ b/src/PhotoGallery/photogallerytest.pro
@@ -1,0 +1,11 @@
+# This build file defines hermetic unit tests for photo gallery related
+# features. The build pulls in only those sources that are required in the
+# context of the test cases, and is independent of the bulk of QGroundControl.
+
+CONFIG += testcase
+QT += testlib
+TARGET = PhotoGalleryTests
+SOURCES = \
+    PhotoGalleryTests.cc
+
+include($$PWD/photogallery_hermetic.pri)

--- a/src/Settings/AppSettings.cc
+++ b/src/Settings/AppSettings.cc
@@ -33,6 +33,7 @@ const char* AppSettings::missionDirectory =         "Missions";
 const char* AppSettings::logDirectory =             "Logs";
 const char* AppSettings::videoDirectory =           "Video";
 const char* AppSettings::crashDirectory =           "CrashLogs";
+const char* AppSettings::photoDirectory =           "Photos";
 
 DECLARE_SETTINGGROUP(App, "")
 {
@@ -126,6 +127,7 @@ void AppSettings::_checkSavePathDirectories(void)
         savePathDir.mkdir(logDirectory);
         savePathDir.mkdir(videoDirectory);
         savePathDir.mkdir(crashDirectory);
+        savePathDir.mkdir(photoDirectory);
     }
 }
 
@@ -190,6 +192,16 @@ QString AppSettings::crashSavePath(void)
     if (!path.isEmpty() && QDir(path).exists()) {
         QDir dir(path);
         return dir.filePath(crashDirectory);
+    }
+    return QString();
+}
+
+QString AppSettings::photoSavePath(void)
+{
+    QString path = savePath()->rawValue().toString();
+    if (!path.isEmpty() && QDir(path).exists()) {
+        QDir dir(path);
+        return dir.filePath(photoDirectory);
     }
     return QString();
 }

--- a/src/Settings/AppSettings.h
+++ b/src/Settings/AppSettings.h
@@ -63,6 +63,7 @@ public:
     Q_PROPERTY(QString logSavePath          READ logSavePath        NOTIFY savePathsChanged)
     Q_PROPERTY(QString videoSavePath        READ videoSavePath      NOTIFY savePathsChanged)
     Q_PROPERTY(QString crashSavePath        READ crashSavePath      NOTIFY savePathsChanged)
+    Q_PROPERTY(QString photoSavePath        READ photoSavePath      NOTIFY savePathsChanged)
 
     Q_PROPERTY(QString planFileExtension        MEMBER planFileExtension        CONSTANT)
     Q_PROPERTY(QString missionFileExtension     MEMBER missionFileExtension     CONSTANT)
@@ -79,6 +80,7 @@ public:
     QString logSavePath         ();
     QString videoSavePath       ();
     QString crashSavePath       ();
+    QString photoSavePath       ();
 
     static MAV_AUTOPILOT    offlineEditingFirmwareTypeFromFirmwareType  (MAV_AUTOPILOT firmwareType);
     static MAV_TYPE         offlineEditingVehicleTypeFromVehicleType    (MAV_TYPE vehicleType);
@@ -102,6 +104,7 @@ public:
     static const char* logDirectory;
     static const char* videoDirectory;
     static const char* crashDirectory;
+    static const char* photoDirectory;
 
 signals:
     void savePathsChanged();

--- a/src/ui/MainRootWindow.qml
+++ b/src/ui/MainRootWindow.qml
@@ -80,6 +80,7 @@ ApplicationWindow {
         analyzeWindow.visible   = false
         flightView.visible      = false
         planViewLoader.visible  = false
+        photoGalleryView.visible = false
         if(isPlanView) {
             toolbar.source  = _planToolbar
         } else {
@@ -110,6 +111,11 @@ ApplicationWindow {
     function showSettingsView() {
         viewSwitch(false)
         settingsWindow.visible = true
+    }
+
+    function showPhotoGalleryView() {
+        viewSwitch(false)
+        photoGalleryView.visible = true
     }
 
     //-------------------------------------------------------------------------
@@ -349,6 +355,15 @@ Item {
         anchors.fill:   parent
         visible:        false
         source:         "AnalyzeView.qml"
+    }
+
+    //-------------------------------------------------------------------------
+    //-- Photo Gallery
+    Loader {
+        id:             photoGalleryView
+        anchors.fill:   parent
+        visible:        false
+        source:         "PhotoGalleryView.qml"
     }
 
     //-------------------------------------------------------------------------

--- a/src/ui/toolbar/Images/PhotoGallery.svg
+++ b/src/ui/toolbar/Images/PhotoGallery.svg
@@ -1,0 +1,72 @@
+<?xml version="1.0" encoding="UTF-8" standalone="no"?>
+<!-- Generator: Adobe Illustrator 19.1.0, SVG Export Plug-In . SVG Version: 6.00 Build 0)  -->
+
+<svg
+   xmlns:dc="http://purl.org/dc/elements/1.1/"
+   xmlns:cc="http://creativecommons.org/ns#"
+   xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#"
+   xmlns:svg="http://www.w3.org/2000/svg"
+   xmlns="http://www.w3.org/2000/svg"
+   xmlns:sodipodi="http://sodipodi.sourceforge.net/DTD/sodipodi-0.dtd"
+   xmlns:inkscape="http://www.inkscape.org/namespaces/inkscape"
+   version="1.1"
+   id="Layer_1"
+   x="0px"
+   y="0px"
+   viewBox="194 896 72 72"
+   style="enable-background:new 194 896 72 72;"
+   xml:space="preserve"
+   sodipodi:docname="ImageGallery.svg"
+   inkscape:version="0.92.4 (5da689c313, 2019-01-14)"><metadata
+   id="metadata11"><rdf:RDF><cc:Work
+       rdf:about=""><dc:format>image/svg+xml</dc:format><dc:type
+         rdf:resource="http://purl.org/dc/dcmitype/StillImage" /><dc:title /></cc:Work></rdf:RDF></metadata><defs
+   id="defs9" /><sodipodi:namedview
+   pagecolor="#ffffff"
+   bordercolor="#666666"
+   borderopacity="1"
+   objecttolerance="10"
+   gridtolerance="10"
+   guidetolerance="10"
+   inkscape:pageopacity="0"
+   inkscape:pageshadow="2"
+   inkscape:window-width="1228"
+   inkscape:window-height="753"
+   id="namedview7"
+   showgrid="false"
+   inkscape:pagecheckerboard="true"
+   inkscape:zoom="3.2777778"
+   inkscape:cx="-6.861226"
+   inkscape:cy="41.641602"
+   inkscape:window-x="251"
+   inkscape:window-y="118"
+   inkscape:window-maximized="0"
+   inkscape:current-layer="Layer_1" />
+<style
+   type="text/css"
+   id="style2">
+	.st0{fill:#FFFFFF;}
+</style>
+
+<rect
+   style="fill:none;fill-opacity:1;stroke:#fffffc;stroke-width:5;stroke-linecap:butt;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
+   id="rect834"
+   width="48.813557"
+   height="40.271187"
+   x="200.71185"
+   y="918.27118"
+   ry="9.4576302"
+   rx="9.4576302" /><path
+   style="color:#000000;font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:medium;line-height:normal;font-family:sans-serif;font-variant-ligatures:normal;font-variant-position:normal;font-variant-caps:normal;font-variant-numeric:normal;font-variant-alternates:normal;font-feature-settings:normal;text-indent:0;text-align:start;text-decoration:none;text-decoration-line:none;text-decoration-style:solid;text-decoration-color:#000000;letter-spacing:normal;word-spacing:normal;text-transform:none;writing-mode:lr-tb;direction:ltr;text-orientation:mixed;dominant-baseline:auto;baseline-shift:baseline;text-anchor:start;white-space:normal;shape-padding:0;clip-rule:nonzero;display:inline;overflow:visible;visibility:visible;opacity:1;isolation:auto;mix-blend-mode:normal;color-interpolation:sRGB;color-interpolation-filters:linearRGB;solid-color:#000000;solid-opacity:1;vector-effect:none;fill:#fffffc;fill-opacity:1;fill-rule:nonzero;stroke:none;stroke-width:5;stroke-linecap:butt;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1;color-rendering:auto;image-rendering:auto;shape-rendering:auto;text-rendering:auto;enable-background:accumulate"
+   d="M 25.626953 6.9570312 C 19.457665 6.9570312 14.34802 11.682606 13.732422 17.695312 L 18.779297 17.695312 C 19.342623 14.398999 22.147483 11.957031 25.626953 11.957031 L 55.525391 11.957031 C 59.423161 11.957031 62.482422 15.018246 62.482422 18.916016 L 62.482422 40.271484 C 62.482422 41.911891 61.935757 43.400293 61.017578 44.578125 L 61.017578 50.876953 C 64.849295 48.879856 67.482422 44.873863 67.482422 40.271484 L 67.482422 18.916016 C 67.482422 12.334726 62.106671 6.9570312 55.525391 6.9570312 L 25.626953 6.9570312 z "
+   transform="translate(194,896)"
+   id="rect834-7" /><path
+   style="fill:none;stroke:#ffffff;stroke-width:4;stroke-linecap:butt;stroke-linejoin:miter;stroke-opacity:1;stroke-miterlimit:4;stroke-dasharray:none"
+   d="m 208.33898,948.47458 7.62712,-9.76272 5.49153,6.40678 L 232.13559,932 l 8.84746,15.25424"
+   id="path872"
+   inkscape:connector-curvature="0" /><circle
+   style="fill:none;fill-opacity:1;stroke:#ffffff;stroke-width:3;stroke-linecap:butt;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
+   id="path874"
+   cx="219.47458"
+   cy="928.79657"
+   r="5.3389831" /></svg>

--- a/src/ui/toolbar/MainToolBar.qml
+++ b/src/ui/toolbar/MainToolBar.qml
@@ -99,6 +99,17 @@ Item {
             }
 
             QGCToolBarButton {
+                id:                 photoGalleryButton
+                anchors.top:        parent.top
+                anchors.bottom:     parent.bottom
+                icon.source:        "/qmlimages/PhotoGallery.svg"
+                onClicked: {
+                    checked = true
+                    mainWindow.showPhotoGalleryView()
+                }
+            }
+
+            QGCToolBarButton {
                 id:                 flyButton
                 anchors.top:        parent.top
                 anchors.bottom:     parent.bottom


### PR DESCRIPTION
Implement facilities to:

- take photos on the drone
- download them into QGC
- view and manage them in a simple way in a photo gallery part

The implementation provided here is also an exercise to improve the ways in which features are kept modular, with as little as possible interference with other code. Some necessary prerequesite baseline hooks are implemented in first few commits of this series, the rest is then fully encapsulated.

This is also an experiment to see how we can bring unit tests into QGroundControl. This is known to be problematic with qmake (only option is to have subdir-project files -- as done here, although not wired to main build).

Note that this is a rebase of https://github.com/mavlink/qgroundcontrol/pull/7921 for upstream -- this is to ensure we meet DIU deadline even if upstream review is taking too long.